### PR TITLE
Rework how component I/O is defined

### DIFF
--- a/canals/component/__init__.py
+++ b/canals/component/__init__.py
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: Apache-2.0
 from canals.component.component import component, ComponentError
 from canals.component.decorators import save_init_params
-from canals.component.input_output import ComponentInput, ComponentOutput, VariadicComponentInput

--- a/canals/component/input_output.py
+++ b/canals/component/input_output.py
@@ -2,78 +2,151 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import logging
-import inspect
-from dataclasses import fields
+from enum import Enum
+from dataclasses import fields, is_dataclass, dataclass, asdict, MISSING
+
+from canals.errors import ComponentError
 
 logger = logging.getLogger(__name__)
 
 
-class BaseIODataclass:  # pylint: disable=too-few-public-methods
+def _make_fields_optional(class_: type):
     """
-    Base class for input and output classes of components.
+    Takes a dataclass definition and modifies its __init__ so that all fields have
+    a default value set.
+    If a field has a default factory use it to set the default value.
+    If a field has neither a default factory or value default to None.
     """
+    defaults = []
+    for field in fields(class_):
+        default = field.default
+        if field.default is MISSING and field.default_factory is MISSING:
+            default = None
+        elif field.default is MISSING and field.default_factory is not MISSING:
+            default = field.default_factory()
+        defaults.append(default)
+    # mypy complains we're accessing __init__ on an instance but it's not in reality.
+    # class_ is a class definition and not an instance of it, so we're good.
+    # Also only I/O dataclasses are meant to be passed to this function making it a bit safer.
+    class_.__init__.__defaults__ = tuple(defaults)  # type: ignore
 
-    def names(self):
-        """
-        Returns the name of all the fields of this dataclass.
-        """
-        return [field.name for field in fields(self)]
 
-
-class Optionalize(type):
+def _make_comparable(class_: type):
     """
-    Makes all the fields of the dataclass optional by setting None as their default value.
-    """
+    Overwrites the existing __eq__ method of class_ with a custom one.
+    This is meant to be used only in I/O dataclasses, it takes into account
+    whether the fields are marked as comparable or not.
 
-    def __call__(cls, *args, **kwargs):
-        obj = cls.__new__(cls, *args, **kwargs)
-        obj.__init__.__func__.__defaults__ = tuple(None for _ in inspect.signature(obj.__init__).parameters)
-        obj.__init__(*args, **kwargs)
-        return obj
+    This is necessary since the automatically created __eq__ method in dataclasses
+    also verifies the type of the class. That causes it to fail if the I/O dataclass
+    is returned by a function.
 
-
-class Variadic(type):
-    """
-    Adds the proper checks to a variadic input dataclass and packs the args into a list for the `__init__` call.
-    """
-
-    def __call__(cls, *args, **kwargs):
-        if kwargs:
-            raise ValueError(f"{cls.__name__} accepts only an unnamed list of positional parameters.")
-
-        obj = cls.__new__(cls, *args)
-
-        if len(inspect.signature(obj.__init__).parameters) != 1:
-            raise ValueError(f"{cls.__name__} accepts only one variadic positional parameter.")
-
-        obj.__init__(list(args))
-        return obj
-
-
-class ComponentInput(BaseIODataclass, metaclass=Optionalize):  # pylint: disable=too-few-public-methods
-    """
-    Represents the input of a component.
+    In here we don't compare the types of self and other but only their fields.
     """
 
-    # dataclasses are uncooperative (don't call `super()`), so we need this flag to check for inheritance
-    _component_input = True
+    def comparator(self, other) -> bool:
+        if not is_dataclass(other):
+            return False
+
+        # We don't care about the order, if they're the same class
+        # the fields will have the same order
+        fields_ = [f.name for f in fields(self) if f.compare]
+        other_fields = [f.name for f in fields(other) if f.compare]
+        if not fields_ == other_fields:
+            return False
+
+        for field in fields_:
+            if not asdict(self)[field] == asdict(other)[field]:
+                return False
+
+        return True
+
+    setattr(class_, ".__eq__", comparator)
 
 
-class VariadicComponentInput(BaseIODataclass, metaclass=Variadic):  # pylint: disable=too-few-public-methods
+class Connection(Enum):
+    INPUT = 1
+    OUTPUT = 2
+    INPUT_VARIADIC = 3
+
+
+def _input(input_function=None, variadic: bool = False):
     """
-    Represents the input of a variadic component.
+    Decorator to mark a method that returns a dataclass defining a Component's input.
+
+    The decorated function becomes a property.
+
+    :param variadic: Set it to true to mark the dataclass returned by input_function as variadic,
+        additional checks are done in this case, defaults to False
     """
 
-    # VariadicComponentInput can't inherit from ComponentInput due to metaclasses clashes
-    # dataclasses are uncooperative (don't call `super()`), so we need this flag to check for inheritance
-    _component_input = True
-    _variadic_component_input = True
+    def decorator(function):
+        def wrapper(self):
+            class_ = function(self)
+            # If the user didn't explicitly declare the returned class
+            # as dataclass we do it out of convenience
+            if not is_dataclass(class_):
+                class_ = dataclass(class_)
+
+            _make_comparable(class_)
+            _make_fields_optional(class_)
+
+            if variadic and len(fields(class_)) > 1:
+                raise ComponentError(f"Variadic input dataclass {class_.__name__} must have only one field")
+
+            if variadic:
+                # Ugly hack to make variadic input work
+                init = class_.__init__
+                class_.__init__ = lambda self, *args: init(self, list(args))
+
+            return class_
+
+        # Magic field to ease some further checks, we set it in the wrapper
+        # function so we access it like this <class>.<function>.fget.__canals_connection__
+        wrapper.__canals_connection__ = Connection.INPUT_VARIADIC if variadic else Connection.INPUT
+
+        # If we don't set the documentation explicitly the user wouldn't be able to access
+        # since we make wrapper a property and not the original function.
+        # This is not essential but a really nice to have.
+        return property(fget=wrapper, doc=function.__doc__)
+
+    # Check if we're called as @_input or @_input()
+    if input_function:
+        # Called with parens
+        return decorator(input_function)
+
+    # Called without parens
+    return decorator
 
 
-class ComponentOutput(BaseIODataclass, metaclass=Optionalize):  # pylint: disable=too-few-public-methods
+def _output(output_function=None):
     """
-    Represents the output of a component.
+    Decorator to mark a method that returns a dataclass defining a Component's output.
+
+    The decorated function becomes a property.
     """
 
-    # dataclasses are uncooperative (don't call `super()`), so we need this flag to check for inheritance
-    _component_output = True
+    def decorator(function):
+        def wrapper(self):
+            class_ = function(self)
+            if not is_dataclass(class_):
+                class_ = dataclass(class_)
+            _make_comparable(class_)
+            return class_
+
+        # Magic field to ease some further checks, we set it in the wrapper
+        # function so we access it like this <class>.<function>.fget.__canals_connection__
+        wrapper.__canals_connection__ = Connection.OUTPUT
+
+        # If we don't set the documentation explicitly the user wouldn't be able to access
+        # since we make wrapper a property and not the original function.
+        # This is not essential but a really nice to have.
+        return property(fget=wrapper, doc=function.__doc__)
+
+    # Check if we're called as @_output or @_output()
+    if output_function:
+        # Called with parens
+        return decorator(output_function)
+
+    # Called without parens
+    return decorator

--- a/canals/component/input_output.py
+++ b/canals/component/input_output.py
@@ -55,8 +55,9 @@ def _make_comparable(class_: type):
         if not fields_ == other_fields:
             return False
 
+        self_dict, other_dict = asdict(self), asdict(other)
         for field in fields_:
-            if not asdict(self)[field] == asdict(other)[field]:
+            if not self_dict[field] == other_dict[field]:
                 return False
 
         return True

--- a/canals/component/input_output.py
+++ b/canals/component/input_output.py
@@ -61,7 +61,7 @@ def _make_comparable(class_: type):
 
         return True
 
-    setattr(class_, ".__eq__", comparator)
+    setattr(class_, "__eq__", comparator)
 
 
 class Connection(Enum):

--- a/canals/component/input_output.py
+++ b/canals/component/input_output.py
@@ -48,11 +48,9 @@ def _make_comparable(class_: type):
         if not is_dataclass(other):
             return False
 
-        # We don't care about the order, if they're the same class
-        # the fields will have the same order
         fields_ = [f.name for f in fields(self) if f.compare]
         other_fields = [f.name for f in fields(other) if f.compare]
-        if not fields_ == other_fields:
+        if not len(fields_) == len(other_fields):
             return False
 
         self_dict, other_dict = asdict(self), asdict(other)

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -14,7 +14,6 @@ from collections import OrderedDict
 import networkx
 
 from canals.errors import PipelineConnectError, PipelineMaxLoops, PipelineRuntimeError, PipelineValidationError
-from canals.component.input_output import ComponentInput
 from canals.draw import draw, convert_for_debug, RenderingEngines
 from canals.pipeline.sockets import InputSocket, OutputSocket, find_input_sockets, find_output_sockets
 from canals.pipeline.validation import validate_pipeline_input
@@ -278,7 +277,7 @@ class Pipeline:
                 logger.info("Warming up component %s...", node)
                 self.graph.nodes[node]["instance"].warm_up()
 
-    def run(self, data: Dict[str, ComponentInput], debug: bool = False) -> Dict[str, Any]:
+    def run(self, data: Dict[str, type], debug: bool = False) -> Dict[str, Any]:
         """
         Runs the pipeline.
 
@@ -447,7 +446,6 @@ class Pipeline:
 
         # Some node upstream didn't run yet, so we should wait for them.
         if not self._all_nodes_to_wait_for_run(nodes_to_wait_for=nodes_to_wait_for):
-
             if not inputs_buffer:
                 # What if there are no components to wait for?
                 raise PipelineRuntimeError(
@@ -497,7 +495,6 @@ class Pipeline:
         # Variadic nodes expect a single list regardless of how many incoming connections they have,
         # but the length of the list should match the length of incoming connections.
         if self.graph.nodes[name]["variadic_input"]:
-
             # Variadic nodes need at least two values
             if not inputs or len(inputs) < 2:
                 return False
@@ -570,7 +567,7 @@ class Pipeline:
             logger.info("* Running %s (visits: %s)", name, self.graph.nodes[name]["visits"])
             logger.debug("   '%s' inputs: %s", name, inputs)
 
-            input_class = instance.Input if hasattr(instance, "Input") else instance.input_type
+            input_class = instance.input
 
             # If the node is variadic, unpack the input
             if self.graph.nodes[name]["variadic_input"]:

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -277,7 +277,7 @@ class Pipeline:
                 logger.info("Warming up component %s...", node)
                 self.graph.nodes[node]["instance"].warm_up()
 
-    def run(self, data: Dict[str, type], debug: bool = False) -> Dict[str, Any]:
+    def run(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:
         """
         Runs the pipeline.
 

--- a/canals/pipeline/save_load.py
+++ b/canals/pipeline/save_load.py
@@ -81,7 +81,6 @@ def marshal_pipelines(pipelines: Dict[str, Pipeline]) -> Dict[str, Any]:
         # Collect components
         pipeline_repr["components"] = {}
         for component_name in pipeline.graph.nodes:
-
             # Check if we saved the same instance twice (or more times) and replace duplicates with references.
             component_instance = pipeline.graph.nodes[component_name]["instance"]
             for existing_component_pipeline, existing_component_name, existing_components in components:
@@ -136,7 +135,6 @@ def unmarshal_pipelines(schema: Dict[str, Any]) -> Dict[str, Pipeline]:  # pylin
     pipelines = {}
     component_instances: Dict[str, object] = {}
     for pipeline_name, pipeline_schema in schema["pipelines"].items():
-
         # Create the Pipeline object
         pipe_args = {"metadata": pipeline_schema.get("metadata", None)}
         if "max_loops_allowed" in pipeline_schema.keys():
@@ -183,18 +181,17 @@ def _discover_dependencies(components: List[object]) -> List[str]:
     return list({module.__name__.split(".")[0] for module in module_names if module is not None}) + ["canals"]
 
 
-def _find_decorated_classes(modules_to_search: List[str], decorator: str = "__canals_component__") -> Dict[str, type]:
+def _find_decorated_classes(modules_to_search: List[str], decorator: str = "__canals_component__") -> Dict[str, Any]:
     """
     Finds all classes decorated with `@components` in all the modules listed in `modules_to_search`.
     Returns a dictionary with the component class name and the component classes.
 
     Note: can be used for other decorators as well by setting the `decorator` parameter.
     """
-    component_classes: Dict[str, type] = {}
+    component_classes: Dict[str, Any] = {}
 
     # Collect all modules
     for module in modules_to_search:
-
         if not module in sys.modules:
             raise ValueError(f"{module} is not imported.")
 

--- a/canals/pipeline/save_load.py
+++ b/canals/pipeline/save_load.py
@@ -195,7 +195,7 @@ def _find_decorated_classes(modules_to_search: List[str], decorator: str = "__ca
         if not module in sys.modules:
             raise ValueError(f"{module} is not imported.")
 
-        for name, entity in getmembers(sys.modules.get(module, None), ismodule):
+        for name, _ in getmembers(sys.modules.get(module, None), ismodule):
             if f"{module}.{name}" in sys.modules:
                 modules_to_search.append(f"{module}.{name}")
 

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Iterable, Dict
+from typing import List, Iterable, Dict, Any
 import logging
 from dataclasses import fields
 
@@ -36,7 +36,7 @@ def find_pipeline_outputs(graph) -> Dict[str, List[OutputSocket]]:
     }
 
 
-def validate_pipeline_input(graph: networkx.MultiDiGraph, input_values: Dict[str, type]) -> Dict[str, type]:
+def validate_pipeline_input(graph: networkx.MultiDiGraph, input_values: Dict[str, Any]) -> Dict[str, Any]:
     """
     Make sure the pipeline is properly built and that the input received makes sense.
     Returns the input values, validated and updated at need.
@@ -66,7 +66,7 @@ def validate_pipeline_input(graph: networkx.MultiDiGraph, input_values: Dict[str
     return input_values
 
 
-def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_values: Dict[str, type]):
+def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_values: Dict[str, Any]):
     """
     Make sure all the inputs nodes are receiving all the values they need, either from the Pipeline's input or from
     other nodes.
@@ -86,7 +86,7 @@ def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_va
                 raise ValueError(f"Missing input: {node}.{socket.name}")
 
 
-def _validate_nodes_receive_only_expected_input(graph: networkx.MultiDiGraph, input_values: Dict[str, type]):
+def _validate_nodes_receive_only_expected_input(graph: networkx.MultiDiGraph, input_values: Dict[str, Any]):
     """
     Make sure that every input node is only receiving input values from EITHER the pipeline's input or another node,
     but never from both.

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,318 +1,184 @@
 from typing import List
 
-from dataclasses import dataclass
-
 import pytest
 
-from canals.component import component, ComponentInput, VariadicComponentInput, ComponentOutput, ComponentError
+from canals.component import component, ComponentError
+
+
+def test_correct_declaration():
+    @component
+    class MockComponent:
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
+
+            return Input
+
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
 
 def test_input_required():
-
     with pytest.raises(
         ComponentError,
-        match="Components must either have an Input dataclass or a 'input_type' property that returns such dataclass",
+        match="No input definition found in Component MockComponent. "
+        "Create a method that returns a dataclass defining the input and "
+        "decorate it with @component.input\(\) to fix the error.",
     ):
 
         @component
         class MockComponent:
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
 
-            def run(self, data) -> Output:
+                return Output
+
+            def run(self, data):
                 return MockComponent.Output(output_value=1)
 
 
 def test_output_required():
-
     with pytest.raises(
         ComponentError,
-        match="Components must either have an Output dataclass or a 'output_type' property that returns such dataclass",
+        match="No output definition found in Component MockComponent. "
+        "Create a method that returns a dataclass defining the output and "
+        "decorate it with @component.output\(\) to fix the error.",
     ):
 
         @component
         class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                input_value: int
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
 
-            def run(self, data: Input):
+                return Input
+
+            def run(self, data):
                 return 1
 
 
-def test_input_as_class():
+def test_variadic_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            single_value: int
-
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
-
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
-
-
-def test_variadic_input_as_class():
-    @component
-    class MockComponent:
-        @dataclass
-        class Input(VariadicComponentInput):
-            single_value: int
-
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
-
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
-
-
-def test_variadic_input_with_more_than_one_param():
-
-    with pytest.raises(ComponentError, match="Variadic inputs can contain only one variadic positional parameter."):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input(VariadicComponentInput):
-                single_value: int
+        @component.input(variadic=True)
+        def input(self):
+            class Input:
                 values: List[int]
 
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
+            return Input
 
-            def run(self, data: Input) -> Output:
-                return MockComponent.Output(output_value=1)
-
-
-def test_input_as_class_must_be_a_dataclass():
-
-    with pytest.raises(ComponentError, match="Input must be a dataclass"):
-
-        @component
-        class MockComponent:
-            class Input(ComponentInput):
-                single_value: int
-
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
-
-            def run(self, data: Input) -> Output:
-                return MockComponent.Output(output_value=1)
-
-
-def test_input_as_class_must_inherit_from_componentinput():
-
-    with pytest.raises(ComponentError, match="Input must inherit from ComponentInput"):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input:
-                single_value: int
-
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
-
-            def run(self, data: Input) -> Output:
-                return MockComponent.Output(output_value=1)
-
-
-def test_input_as_property():
-    @component
-    class MockComponent:
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
-
-        def input_type(self):
-            return None
-
-        def run(self, data) -> Output:
-            return MockComponent.Output(output_value=1)
-
-
-def test_output_as_class():
-    @component
-    class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            single_value: int
-
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
-
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
-
-
-def test_output_as_class_must_be_a_dataclass():
-
-    with pytest.raises(ComponentError, match="Output must be a dataclass"):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
-
-            class Output(ComponentOutput):
-                output_value: int
-
-            def run(self, data: Input) -> Output:
-                return MockComponent.Output()
-
-
-def test_output_as_class_must_inherit_from_componentoutput():
-
-    with pytest.raises(ComponentError, match="Output must inherit from ComponentOutput"):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
-
-            @dataclass
+        @component.output
+        def output(self):
             class Output:
                 output_value: int
 
-            def run(self, data: Input) -> Output:
-                return MockComponent.Output(output_value=1)
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
+
+    # Variadic input is verified when accessing the decorated property
+    assert MockComponent().input
 
 
-def test_output_as_property():
+def test_variadic_input_with_more_than_one_param():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input(variadic=True)
+        def input(self):
+            class Input:
+                single_value: int
+                values: List[int]
 
-        def output_type(self):
-            return None
+            return Input
 
-        def run(self, data: Input):
-            return self.output_type()
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
+
+    # Variadic input is verified when accessing the decorated property
+    with pytest.raises(ComponentError, match="Variadic input dataclass Input must have only one field"):
+        assert MockComponent().input
 
 
 def test_check_for_run():
-
     with pytest.raises(ComponentError, match="must have a 'run\(\)' method"):
 
         @component
         class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
 
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
+                return Input
+
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
+
+                return Output
 
 
 def test_run_takes_only_one_param():
-
     with pytest.raises(ComponentError, match="must accept only a single parameter called 'data'."):
 
         @component
         class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
 
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
+                return Input
 
-            def run(self, data: Input, something_else: int) -> Output:
-                return MockComponent.Output(output_value=1)
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
+
+                return Output
+
+            def run(self, data, something_else: int):
+                return self.output(output_value=1)
 
 
-def test_run_takes_only_data():
-
+def test_run_takes_only_kwarg_data():
     with pytest.raises(ComponentError, match="must accept a parameter called 'data'."):
 
         @component
         class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
 
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
+                return Input
 
-            def run(self, wrong_name: Input) -> Output:
-                return MockComponent.Output(output_value=1)
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
 
+                return Output
 
-def test_run_data_must_be_typed_if_input_is_a_class():
-
-    with pytest.raises(ComponentError, match="'data' must be typed"):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
-
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
-
-            def run(self, data) -> Output:
-                return MockComponent.Output(output_value=1)
-
-
-def test_run_data_needs_no_type_if_input_is_not_a_class():
-    @component
-    class MockComponent:
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
-
-        def input_type(self):
-            return None
-
-        def run(self, data) -> Output:
-            return MockComponent.Output(output_value=1)
-
-
-def test_run_return_must_be_typed_if_output_is_a_class():
-
-    with pytest.raises(ComponentError, match="must declare the type of its return value"):
-
-        @component
-        class MockComponent:
-            @dataclass
-            class Input(ComponentInput):
-                single_value: int
-
-            @dataclass
-            class Output(ComponentOutput):
-                output_value: int
-
-            def run(self, data: Input):
-                return MockComponent.Output(output_value=1)
-
-
-def test_run_return_needs_no_type_if_output_is_not_a_class():
-    @component
-    class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
-
-        def output_type(self):
-            return None
-
-        def run(self, data: Input):
-            return self.output_type()(output_value=1)
+            def run(self, wrong_name):
+                return self.output(output_value=1)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -25,6 +25,9 @@ def test_correct_declaration():
         def run(self, data):
             return self.output(output_value=1)
 
+    # Verifies also instantiation works with no issues
+    assert MockComponent()
+
 
 def test_input_required():
     with pytest.raises(
@@ -66,6 +69,72 @@ def test_output_required():
 
             def run(self, data):
                 return 1
+
+
+def test_only_single_input_defined():
+    with pytest.raises(
+        ComponentError,
+        match="Multiple input definitions found for Component MockComponent",
+    ):
+
+        @component
+        class MockComponent:
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
+
+                return Input
+
+            @component.input
+            def another_input(self):
+                class Input:
+                    input_value: int
+
+                return Input
+
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
+
+                return Output
+
+            def run(self, data):
+                return self.output(output_value=1)
+
+
+def test_only_single_output_defined():
+    with pytest.raises(
+        ComponentError,
+        match="Multiple output definitions found for Component MockComponent",
+    ):
+
+        @component
+        class MockComponent:
+            @component.input
+            def input(self):
+                class Input:
+                    input_value: int
+
+                return Input
+
+            @component.output
+            def output(self):
+                class Output:
+                    output_value: int
+
+                return Output
+
+            @component.output
+            def another_output(self):
+                class Output:
+                    output_value: int
+
+                return Output
+
+            def run(self, data):
+                return self.output(output_value=1)
 
 
 def test_variadic_input():

--- a/test/pipelines/integration/test_complex_pipeline.py
+++ b/test/pipelines/integration/test_complex_pipeline.py
@@ -82,11 +82,13 @@ def test_complex_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "complex_pipeline.png")
 
-    results = pipeline.run({"greet_first": Greet.Input(value=1), "greet_enumerator": Greet.Input(value=1)})
+    results = pipeline.run({"greet_first": Greet().input(value=1), "greet_enumerator": Greet().input(value=1)})
     pprint(results)
     print("accumulated: ", accumulate.state)
 
-    assert results == {"accumulate_3": Accumulate.Output(value=9), "add_five": AddFixedValue.Output(value=-7)}
+    assert len(results) == 2
+    assert results["accumulate_3"].value == 9
+    assert results["add_five"].value == -7
     assert accumulate.state == 9
 
 

--- a/test/pipelines/integration/test_fixed_decision_and_merge_pipeline.py
+++ b/test/pipelines/integration/test_fixed_decision_and_merge_pipeline.py
@@ -35,21 +35,23 @@ def test_pipeline(tmp_path):
 
     results = pipeline.run(
         {
-            "add_one": AddFixedValue.Input(value=1),
-            "add_two": AddFixedValue.Input(add=2),
+            "add_one": AddFixedValue().input(value=1),
+            "add_two": AddFixedValue().input(add=2),
         }
     )
     pprint(results)
-    assert results == {"add_two": AddFixedValue.Output(value=8)}
+    assert len(results) == 1
+    assert results["add_two"].value == 8
 
     results = pipeline.run(
         {
-            "add_one": AddFixedValue.Input(value=2),
-            "add_two": AddFixedValue.Input(add=2),
+            "add_one": AddFixedValue().input(value=2),
+            "add_two": AddFixedValue().input(add=2),
         }
     )
     pprint(results)
-    assert results == {"diff": Subtract.Output(difference=7)}
+    assert len(results) == 1
+    assert results["diff"].difference == 7
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_fixed_decision_pipeline.py
+++ b/test/pipelines/integration/test_fixed_decision_pipeline.py
@@ -29,13 +29,13 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "fixed_decision_pipeline.png")
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=1)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=1)})
     pprint(results)
-    assert results == {"add_three": AddFixedValue.Output(value=15)}
+    assert results == {"add_three": AddFixedValue().output(value=15)}
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=2)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=2)})
     pprint(results)
-    assert results == {"double": Double.Output(value=6)}
+    assert results == {"double": Double().output(value=6)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_fixed_merging_pipeline.py
+++ b/test/pipelines/integration/test_fixed_merging_pipeline.py
@@ -13,7 +13,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_pipeline(tmp_path):
-
     add_two = AddFixedValue(add=2)
     diff = Subtract()
 
@@ -33,13 +32,13 @@ def test_pipeline(tmp_path):
 
     results = pipeline.run(
         {
-            "first_addition": AddFixedValue.Input(value=1),
-            "third_addition": AddFixedValue.Input(value=1),
+            "first_addition": AddFixedValue().input(value=1),
+            "third_addition": AddFixedValue().input(value=1),
         }
     )
     pprint(results)
 
-    assert results == {"fourth_addition": AddFixedValue.Output(value=3)}
+    assert results == {"fourth_addition": AddFixedValue().output(value=3)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_linear_pipeline.py
+++ b/test/pipelines/integration/test_linear_pipeline.py
@@ -22,10 +22,10 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "linear_pipeline.png")
 
-    results = pipeline.run({"first_addition": AddFixedValue.Input(value=1)})
+    results = pipeline.run({"first_addition": AddFixedValue().input(value=1)})
     pprint(results)
 
-    assert results == {"second_addition": AddFixedValue.Output(value=7)}
+    assert results == {"second_addition": AddFixedValue().output(value=7)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_looping_and_merge_pipeline.py
+++ b/test/pipelines/integration/test_looping_and_merge_pipeline.py
@@ -35,12 +35,12 @@ def test_pipeline(tmp_path):
     pipeline.draw(tmp_path / "looping_and_merge_pipeline.png")
 
     results = pipeline.run(
-        {"merge": merge_loop.input_type(8), "sum": Sum.Input(2)},
+        {"merge": merge_loop.input(8), "sum": Sum().input(2)},
     )
     pprint(results)
     print("accumulate: ", accumulator.state)
 
-    assert results == {"sum": Sum.Output(total=23)}
+    assert results == {"sum": Sum().output(total=23)}
     assert accumulator.state == 19
 
 

--- a/test/pipelines/integration/test_looping_pipeline.py
+++ b/test/pipelines/integration/test_looping_pipeline.py
@@ -30,11 +30,11 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "looping_pipeline.png")
 
-    results = pipeline.run({"merge": merge_loop.input_type(4)})
+    results = pipeline.run({"merge": merge_loop.input(4)})
     pprint(results)
     print("accumulator: ", accumulator.state)
 
-    assert results == {"add_two": AddFixedValue.Output(value=18)}
+    assert results == {"add_two": AddFixedValue().output(value=18)}
     assert accumulator.state == 16
 
 

--- a/test/pipelines/integration/test_parallel_branches_pipeline.py
+++ b/test/pipelines/integration/test_parallel_branches_pipeline.py
@@ -31,13 +31,13 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "parallel_branches_pipeline.png")
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=1)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=1)})
     pprint(results)
 
     assert results == {
-        "add_one_again": AddFixedValue.Output(value=6),
-        "add_ten": AddFixedValue.Output(value=12),
-        "double": Double.Output(value=4),
+        "add_one_again": AddFixedValue().output(value=6),
+        "add_ten": AddFixedValue().output(value=12),
+        "double": Double().output(value=4),
     }
 
 

--- a/test/pipelines/integration/test_variable_decision_and_merge_pipeline.py
+++ b/test/pipelines/integration/test_variable_decision_and_merge_pipeline.py
@@ -35,13 +35,13 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "variable_decision_and_merge_pipeline.png")
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=1)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=1)})
     pprint(results)
-    assert results == {"sum": Sum.Output(total=14)}
+    assert results == {"sum": Sum().output(total=14)}
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=2)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=2)})
     pprint(results)
-    assert results == {"sum": Sum.Output(total=17)}
+    assert results == {"sum": Sum().output(total=17)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_variable_decision_pipeline.py
+++ b/test/pipelines/integration/test_variable_decision_pipeline.py
@@ -31,10 +31,10 @@ def test_pipeline(tmp_path):
 
     pipeline.draw(tmp_path / "variable_decision_pipeline.png")
 
-    results = pipeline.run({"add_one": AddFixedValue.Input(value=1)})
+    results = pipeline.run({"add_one": AddFixedValue().input(value=1)})
     pprint(results)
 
-    assert results == {"add_one_again": AddFixedValue.Output(value=6)}
+    assert results == {"add_one_again": AddFixedValue().output(value=6)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/integration/test_variable_merging_pipeline.py
+++ b/test/pipelines/integration/test_variable_merging_pipeline.py
@@ -13,7 +13,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_pipeline(tmp_path):
-
     add_two = AddFixedValue(add=2)
     make_the_sum = Sum()
 
@@ -34,13 +33,13 @@ def test_pipeline(tmp_path):
 
     results = pipeline.run(
         {
-            "first_addition": AddFixedValue.Input(value=1),
-            "third_addition": AddFixedValue.Input(value=1),
+            "first_addition": AddFixedValue().input(value=1),
+            "third_addition": AddFixedValue().input(value=1),
         }
     )
     pprint(results)
 
-    assert results == {"fourth_addition": AddFixedValue.Output(value=12)}
+    assert results == {"fourth_addition": AddFixedValue().output(value=12)}
 
 
 if __name__ == "__main__":

--- a/test/pipelines/unit/test_find_unambiguous_connection.py
+++ b/test/pipelines/unit/test_find_unambiguous_connection.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import pytest
 
 from canals.errors import PipelineConnectError
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 from canals.pipeline.sockets import find_input_sockets, find_output_sockets
 from canals.pipeline.connections import find_unambiguous_connection
 
@@ -12,29 +12,41 @@ from canals.pipeline.connections import find_unambiguous_connection
 def test_find_unambiguous_connection_no_connection_possible():
     @component
     class Component1:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component1.Output(output_value=data.input_value)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=data.input_value)
 
     @component
     class Component2:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: str
+        @component.input
+        def input(self):
+            class Input:
+                input_value: str
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: str
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component2.Output(output_value=data.input_value)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: str
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=data.input_value)
 
     expected_message = """Cannot connect 'comp1' with 'comp2': no matching connections available.
 'comp1':
@@ -54,31 +66,43 @@ def test_find_unambiguous_connection_no_connection_possible():
 def test_find_unambiguous_connection_many_connections_possible_name_matches():
     @component
     class Component1:
-        @dataclass
-        class Input(ComponentInput):
-            value: str
+        @component.input
+        def input(self):
+            class Input:
+                value: str
 
-        @dataclass
-        class Output(ComponentOutput):
-            value: str
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component1.Output(value=data.value)
+        @component.output
+        def output(self):
+            class Output:
+                value: str
+
+            return Output
+
+        def run(self, data):
+            return self.output(value=data.value)
 
     @component
     class Component2:
-        @dataclass
-        class Input(ComponentInput):
-            value: str
-            othervalue: str
-            yetanothervalue: str
+        @component.input
+        def input(self):
+            class Input:
+                value: str
+                othervalue: str
+                yetanothervalue: str
 
-        @dataclass
-        class Output(ComponentOutput):
-            value: str
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component2.Output(value=data.value)
+        @component.output
+        def output(self):
+            class Output:
+                value: str
+
+            return Output
+
+        def run(self, data):
+            return self.output(value=data.value)
 
     comp1 = Component1()
     comp2 = Component2()
@@ -94,31 +118,43 @@ def test_find_unambiguous_connection_many_connections_possible_name_matches():
 def test_find_unambiguous_connection_many_connections_possible_no_name_matches():
     @component
     class Component1:
-        @dataclass
-        class Input(ComponentInput):
-            value: str
+        @component.input
+        def input(self):
+            class Input:
+                value: str
 
-        @dataclass
-        class Output(ComponentOutput):
-            value: str
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component1.Output(value=data.value)
+        @component.output
+        def output(self):
+            class Output:
+                value: str
+
+            return Output
+
+        def run(self, data):
+            return self.output(value=data.value)
 
     @component
     class Component2:
-        @dataclass
-        class Input(ComponentInput):
-            value1: str
-            value2: str
-            value3: str
+        @component.input
+        def input(self):
+            class Input:
+                value1: str
+                value2: str
+                value3: str
 
-        @dataclass
-        class Output(ComponentOutput):
-            value: str
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return Component2.Output(value=data.value1)
+        @component.output
+        def output(self):
+            class Output:
+                value: str
+
+            return Output
+
+        def run(self, data):
+            return self.output(value=data.value1)
 
     expected_message = """Cannot connect 'comp1' with 'comp2': more than one connection is possible between these components. Please specify the connection name, like: pipeline.connect\('comp1.value', 'comp2.value1'\).
 'comp1':

--- a/test/pipelines/unit/test_input_sockets.py
+++ b/test/pipelines/unit/test_input_sockets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from canals.component import component, ComponentInput, ComponentOutput, VariadicComponentInput, ComponentError
+from canals.component import component
 from canals.pipeline.sockets import (
     find_input_sockets,
     InputSocket,
@@ -15,16 +15,22 @@ from canals.pipeline.sockets import (
 def test_find_input_sockets_one_regular_builtin_type_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=data.input_value)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=data.input_value)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -35,18 +41,24 @@ def test_find_input_sockets_one_regular_builtin_type_input():
 def test_find_input_sockets_many_regular_builtin_type_inputs():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            int_value: int
-            str_value: str
-            bool_value: bool
+        @component.input
+        def input(self):
+            class Input:
+                int_value: int
+                str_value: str
+                bool_value: bool
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=data.int_value)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=data.int_value)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -64,16 +76,22 @@ def test_find_input_sockets_one_regular_object_type_input():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: MyObject
+        @component.input
+        def input(self):
+            class Input:
+                input_value: MyObject
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -84,16 +102,22 @@ def test_find_input_sockets_one_regular_object_type_input():
 def test_find_input_sockets_one_union_type_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: Union[str, int]
+        @component.input
+        def input(self):
+            class Input:
+                input_value: Union[str, int]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     with pytest.raises(ValueError, match="Components do not support Union types for connections"):
@@ -103,16 +127,22 @@ def test_find_input_sockets_one_union_type_input():
 def test_find_input_sockets_one_optional_builtin_type_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: Optional[int] = None
+        @component.input
+        def input(self):
+            class Input:
+                input_value: Optional[int] = None
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -126,16 +156,22 @@ def test_find_input_sockets_one_optional_object_type_input():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: Optional[MyObject] = None
+        @component.input
+        def input(self):
+            class Input:
+                input_value: Optional[MyObject] = None
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -146,19 +182,25 @@ def test_find_input_sockets_one_optional_object_type_input():
 def test_find_input_sockets_sequences_of_builtin_type_input_non_variadic():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            list_value: List[int]
-            set_value: Set[int]
-            sequence_value: Sequence[int]
-            iterable_value: Iterable[int]
+        @component.input
+        def input(self):
+            class Input:
+                list_value: List[int]
+                set_value: Set[int]
+                sequence_value: Sequence[int]
+                iterable_value: Iterable[int]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -177,19 +219,25 @@ def test_find_input_sockets_sequences_of_object_type_input_non_variadic():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            list_value: List[MyObject]
-            set_value: Set[MyObject]
-            sequence_value: Sequence[MyObject]
-            iterable_value: Iterable[MyObject]
+        @component.input
+        def input(self):
+            class Input:
+                list_value: List[MyObject]
+                set_value: Set[MyObject]
+                sequence_value: Sequence[MyObject]
+                iterable_value: Iterable[MyObject]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -205,17 +253,23 @@ def test_find_input_sockets_sequences_of_object_type_input_non_variadic():
 def test_find_input_sockets_mappings_of_builtin_type_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            dict_value: Dict[str, int]
-            mapping_value: Mapping[str, int]
+        @component.input
+        def input(self):
+            class Input:
+                dict_value: Dict[str, int]
+                mapping_value: Mapping[str, int]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -232,17 +286,23 @@ def test_find_input_sockets_mappings_of_object_type_input():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            dict_value: Dict[str, MyObject]
-            mapping_value: Mapping[str, MyObject]
+        @component.input
+        def input(self):
+            class Input:
+                dict_value: Dict[str, MyObject]
+                mapping_value: Mapping[str, MyObject]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -259,16 +319,22 @@ def test_find_input_sockets_tuple_type_input():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            tuple_value: Tuple[str, MyObject]
+        @component.input
+        def input(self):
+            class Input:
+                tuple_value: Tuple[str, MyObject]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -281,16 +347,22 @@ def test_find_input_sockets_tuple_type_input():
 def test_find_input_sockets_one_variadic_builtin_input():
     @component
     class MockComponent:
-        @dataclass
-        class Input(VariadicComponentInput):
-            values: List[int]
+        @component.input(variadic=True)
+        def input(self):
+            class Input:
+                values: List[int]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)
@@ -306,16 +378,22 @@ def test_find_input_sockets_variadic_object_input():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(VariadicComponentInput):
-            values: List[MyObject]
+        @component.input(variadic=True)
+        def input(self):
+            class Input:
+                values: List[MyObject]
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_input_sockets(comp)

--- a/test/pipelines/unit/test_output_sockets.py
+++ b/test/pipelines/unit/test_output_sockets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from canals.component import component, ComponentInput, ComponentOutput, VariadicComponentInput, ComponentError
+from canals.component import component
 from canals.pipeline.sockets import (
     find_output_sockets,
     OutputSocket,
@@ -15,16 +15,22 @@ from canals.pipeline.sockets import (
 def test_find_output_sockets_one_regular_builtin_type_output():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: int
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: int
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -35,18 +41,24 @@ def test_find_output_sockets_one_regular_builtin_type_output():
 def test_find_output_sockets_many_regular_builtin_type_outputs():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            int_value: int
-            str_value: str
-            bool_value: bool
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(int_value=1, str_value="1", bool_value=True)
+        @component.output
+        def output(self):
+            class Output:
+                int_value: int
+                str_value: str
+                bool_value: bool
+
+            return Output
+
+        def run(self, data):
+            return self.output(int_value=1, str_value="1", bool_value=True)
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -64,16 +76,22 @@ def test_find_output_sockets_one_regular_object_type_output():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: MyObject
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=MyObject())
+        @component.output
+        def output(self):
+            class Output:
+                output_value: MyObject
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=MyObject())
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -84,16 +102,22 @@ def test_find_output_sockets_one_regular_object_type_output():
 def test_find_output_sockets_one_union_type_output():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: Union[str, int]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: Union[str, int]
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     with pytest.raises(ValueError, match="Components do not support Union types for connections"):
@@ -103,16 +127,22 @@ def test_find_output_sockets_one_union_type_output():
 def test_find_output_sockets_one_optional_builtin_type_output():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: Optional[int] = None
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=1)
+        @component.output
+        def output(self):
+            class Output:
+                output_value: Optional[int] = None
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=1)
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -126,16 +156,22 @@ def test_find_output_sockets_one_optional_object_type_output():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            output_value: Optional[MyObject] = None
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(output_value=MyObject())
+        @component.output
+        def output(self):
+            class Output:
+                output_value: Optional[MyObject] = None
+
+            return Output
+
+        def run(self, data):
+            return self.output(output_value=MyObject())
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -146,19 +182,25 @@ def test_find_output_sockets_one_optional_object_type_output():
 def test_find_output_sockets_sequences_of_builtin_type_output():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            list_value: List[int]
-            set_value: Set[int]
-            sequence_value: Sequence[int]
-            iterable_value: Iterable[int]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
+        @component.output
+        def output(self):
+            class Output:
+                list_value: List[int]
+                set_value: Set[int]
+                sequence_value: Sequence[int]
+                iterable_value: Iterable[int]
+
+            return Output
+
+        def run(self, data):
+            return self.output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -177,19 +219,25 @@ def test_find_output_sockets_sequences_of_object_type_output():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            list_value: List[MyObject]
-            set_value: Set[MyObject]
-            sequence_value: Sequence[MyObject]
-            iterable_value: Iterable[MyObject]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
+        @component.output
+        def output(self):
+            class Output:
+                list_value: List[MyObject]
+                set_value: Set[MyObject]
+                sequence_value: Sequence[MyObject]
+                iterable_value: Iterable[MyObject]
+
+            return Output
+
+        def run(self, data):
+            return self.output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -205,17 +253,23 @@ def test_find_output_sockets_sequences_of_object_type_output():
 def test_find_output_sockets_mappings_of_builtin_type_output():
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            dict_value: Dict[str, int]
-            mapping_value: Mapping[str, int]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(dict_value={}, mapping_value={})
+        @component.output
+        def output(self):
+            class Output:
+                dict_value: Dict[str, int]
+                mapping_value: Mapping[str, int]
+
+            return Output
+
+        def run(self, data):
+            return self.output(dict_value={}, mapping_value={})
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -232,17 +286,23 @@ def test_find_output_sockets_mappings_of_object_type_output():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            dict_value: Dict[str, MyObject]
-            mapping_value: Mapping[str, MyObject]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(dict_value={}, mapping_value={})
+        @component.output
+        def output(self):
+            class Output:
+                dict_value: Dict[str, MyObject]
+                mapping_value: Mapping[str, MyObject]
+
+            return Output
+
+        def run(self, data):
+            return self.output(dict_value={}, mapping_value={})
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)
@@ -259,16 +319,22 @@ def test_find_output_sockets_tuple_type_output():
 
     @component
     class MockComponent:
-        @dataclass
-        class Input(ComponentInput):
-            input_value: int
+        @component.input
+        def input(self):
+            class Input:
+                input_value: int
 
-        @dataclass
-        class Output(ComponentOutput):
-            tuple_value: Tuple[str, MyObject]
+            return Input
 
-        def run(self, data: Input) -> Output:
-            return MockComponent.Output(tuple_value=("a", MyObject()))
+        @component.output
+        def output(self):
+            class Output:
+                tuple_value: Tuple[str, MyObject]
+
+            return Output
+
+        def run(self, data):
+            return self.output(tuple_value=("a", MyObject()))
 
     comp = MockComponent()
     sockets = find_output_sockets(comp)

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -151,7 +151,7 @@ def test_validate_pipeline_input_unknown_component():
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
     with pytest.raises(ValueError, match="Pipeline received data for unknown component\(s\): test_component"):
-        pipe.run({"test_component": Double.Input(value=1)})
+        pipe.run({"test_component": Double().input(value=1)})
 
 
 def test_validate_pipeline_input_all_necessary_input_is_present():
@@ -168,10 +168,10 @@ def test_validate_pipeline_input_all_necessary_input_is_present_considering_defa
     pipe.add_component("comp1", AddFixedValue())
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
-    pipe.run({"comp1": AddFixedValue.Input(value=1)})
-    pipe.run({"comp1": AddFixedValue.Input(value=1, add=1)})
+    pipe.run({"comp1": AddFixedValue().input(value=1)})
+    pipe.run({"comp1": AddFixedValue().input(value=1, add=1)})
     with pytest.raises(ValueError, match="Missing input: comp1.value"):
-        pipe.run({"comp1": AddFixedValue.Input(add=1)})
+        pipe.run({"comp1": AddFixedValue().input(add=1)})
 
 
 def test_validate_pipeline_input_only_expected_input_is_present():
@@ -180,7 +180,7 @@ def test_validate_pipeline_input_only_expected_input_is_present():
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
     with pytest.raises(ValueError, match="The input value of comp2 is already taken by node comp1"):
-        pipe.run({"comp1": Double.Input(value=1), "comp2": Double.Input(value=1)})
+        pipe.run({"comp1": Double().input(value=1), "comp2": Double().input(value=1)})
 
 
 def test_validate_pipeline_input_only_expected_input_is_present_including_unknown_names():
@@ -190,7 +190,7 @@ def test_validate_pipeline_input_only_expected_input_is_present_including_unknow
     pipe.connect("comp1", "comp2")
 
     with pytest.raises(ValueError, match="Component comp1 is not expecting any input value called add"):
-        pipe.run({"comp1": AddFixedValue.Input(value=1, add=3)})
+        pipe.run({"comp1": AddFixedValue().input(value=1, add=3)})
 
 
 def test_validate_pipeline_input_only_expected_input_is_present_and_defaults_dont_interfere():
@@ -198,4 +198,4 @@ def test_validate_pipeline_input_only_expected_input_is_present_and_defaults_don
     pipe.add_component("comp1", AddFixedValue(add=10))
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
-    pipe.run({"comp1": AddFixedValue.Input(value=1, add=5)})
+    pipe.run({"comp1": AddFixedValue().input(value=1, add=5)})

--- a/test/sample_components/test_accumulate.py
+++ b/test/sample_components/test_accumulate.py
@@ -20,14 +20,14 @@ class Accumulate:
     are not directly serializable.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             value: int

--- a/test/sample_components/test_accumulate.py
+++ b/test/sample_components/test_accumulate.py
@@ -5,10 +5,8 @@ from typing import Union, Callable, Optional
 import sys
 import builtins
 from importlib import import_module
-from dataclasses import dataclass
 
-import pytest
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 from canals.testing import BaseTestComponent
 
 
@@ -22,13 +20,19 @@ class Accumulate:
     are not directly serializable.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
 
-    @dataclass
-    class Output(ComponentOutput):
-        value: int
+        return Input
+
+    @component.output
+    def output(self):
+        class Output:
+            value: int
+
+        return Output
 
     def __init__(self, function: Optional[Union[Callable, str]] = None):
         """
@@ -47,9 +51,9 @@ class Accumulate:
             # 'function' is not serializable by default, so we serialize it manually.
             self.init_parameters = {"function": self._save_function(function)}
 
-    def run(self, data: Input) -> Output:
+    def run(self, data):
         self.state = self.function(self.state, data.value)
-        return Accumulate.Output(value=self.state)
+        return self.output(value=self.state)
 
     def _load_function(self, function: Union[Callable, str]):
         """
@@ -98,12 +102,12 @@ class TestAccumulate(BaseTestComponent):
 
     def test_accumulate_default(self):
         component = Accumulate()
-        results = component.run(Accumulate.Input(value=10))
-        assert results == Accumulate.Output(value=10)
+        results = component.run(component.input(value=10))
+        assert results == component.output(value=10)
         assert component.state == 10
 
-        results = component.run(Accumulate.Input(value=1))
-        assert results == Accumulate.Output(value=11)
+        results = component.run(component.input(value=1))
+        assert results == component.output(value=11)
         assert component.state == 11
 
         assert component.init_parameters == {}
@@ -111,12 +115,12 @@ class TestAccumulate(BaseTestComponent):
     def test_accumulate_callable(self):
         component = Accumulate(function=my_subtract)
 
-        results = component.run(Accumulate.Input(value=10))
-        assert results == Accumulate.Output(value=-10)
+        results = component.run(component.input(value=10))
+        assert results == component.output(value=-10)
         assert component.state == -10
 
-        results = component.run(Accumulate.Input(value=1))
-        assert results == Accumulate.Output(value=-11)
+        results = component.run(component.input(value=1))
+        assert results == component.output(value=-11)
         assert component.state == -11
 
         assert component.init_parameters == {
@@ -126,12 +130,12 @@ class TestAccumulate(BaseTestComponent):
     def test_accumulate_string(self):
         component = Accumulate(function="test.sample_components.test_accumulate.my_subtract")
 
-        results = component.run(Accumulate.Input(value=10))
-        assert results == Accumulate.Output(value=-10)
+        results = component.run(component.input(value=10))
+        assert results == component.output(value=-10)
         assert component.state == -10
 
-        results = component.run(Accumulate.Input(value=1))
-        assert results == Accumulate.Output(value=-11)
+        results = component.run(component.input(value=1))
+        assert results == component.output(value=-11)
         assert component.state == -11
 
         assert component.init_parameters == {

--- a/test/sample_components/test_add_value.py
+++ b/test/sample_components/test_add_value.py
@@ -3,11 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 
-from dataclasses import dataclass
 
-import pytest
-
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 from canals.testing.test_component import BaseTestComponent
 
 
@@ -17,21 +14,27 @@ class AddFixedValue:
     Adds the value of `add` to `value`. If not given, `add` defaults to 1.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
-        add: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
+            add: int
 
-    @dataclass
-    class Output(ComponentOutput):
-        value: int
+        return Input
+
+    @component.output
+    def output(self):
+        class Output:
+            value: int
+
+        return Output
 
     def __init__(self, add: Optional[int] = 1):
         if add:
             self.defaults = {"add": add}
 
-    def run(self, data: Input) -> Output:
-        return AddFixedValue.Output(value=data.value + data.add)
+    def run(self, data):
+        return self.output(value=data.value + data.add)
 
 
 class TestAddFixedValue(BaseTestComponent):
@@ -43,6 +46,6 @@ class TestAddFixedValue(BaseTestComponent):
 
     def test_addvalue(self):
         component = AddFixedValue()
-        results = component.run(AddFixedValue.Input(value=50, add=10))
-        assert results == AddFixedValue.Output(value=60)
+        results = component.run(component.input(value=50, add=10))
+        assert results == component.output(value=60)
         assert component.init_parameters == {}

--- a/test/sample_components/test_add_value.py
+++ b/test/sample_components/test_add_value.py
@@ -14,7 +14,7 @@ class AddFixedValue:
     Adds the value of `add` to `value`. If not given, `add` defaults to 1.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
@@ -22,7 +22,7 @@ class AddFixedValue:
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             value: int

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -12,14 +12,14 @@ class Double:
     Doubles the input value.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             value: int

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -1,11 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
 
-import pytest
-
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 from canals.testing import BaseTestComponent
 
 
@@ -15,23 +12,25 @@ class Double:
     Doubles the input value.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
 
-    @dataclass
-    class Output(ComponentOutput):
-        value: int
+        return Input
 
-    def run(self, data: Input) -> Output:
+    @component.output
+    def output(self):
+        class Output:
+            value: int
+
+        return Output
+
+    def run(self, data):
         """
         Doubles the input value
         """
-        return Double.Output(value=data.value * 2)
-
-
-import pytest
-from canals.testing import BaseTestComponent
+        return self.output(value=data.value * 2)
 
 
 class TestDouble(BaseTestComponent):
@@ -40,6 +39,6 @@ class TestDouble(BaseTestComponent):
 
     def test_double_default(self):
         component = Double()
-        results = component.run(Double.Input(value=10))
-        assert results == Double.Output(value=20)
+        results = component.run(component.input(value=10))
+        assert results == component.output(value=20)
         assert component.init_parameters == {}

--- a/test/sample_components/test_greet.py
+++ b/test/sample_components/test_greet.py
@@ -18,7 +18,7 @@ class Greet:
     Logs a greeting message without affecting the value passing on the connection.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
@@ -27,7 +27,7 @@ class Greet:
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             value: int

--- a/test/sample_components/test_greet.py
+++ b/test/sample_components/test_greet.py
@@ -4,12 +4,9 @@
 from typing import Optional
 import logging
 
-from dataclasses import dataclass
-
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 logger = logging.getLogger(__name__)
@@ -21,15 +18,21 @@ class Greet:
     Logs a greeting message without affecting the value passing on the connection.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
-        message: str
-        log_level: str
+    @component.input
+    def input(self):
+        class Input:
+            value: int
+            message: str
+            log_level: str
 
-    @dataclass
-    class Output(ComponentOutput):
-        value: int
+        return Input
+
+    @component.output
+    def output(self):
+        class Output:
+            value: int
+
+        return Output
 
     def __init__(
         self,
@@ -44,7 +47,7 @@ class Greet:
             raise ValueError(f"This log level does not exist: {log_level}")
         self.defaults = {"message": message, "log_level": log_level}
 
-    def run(self, data: Input) -> Output:
+    def run(self, data):
         """
         Logs a greeting message without affecting the value passing on the connection.
         """
@@ -54,7 +57,7 @@ class Greet:
             raise ValueError(f"This log level does not exist: {data.log_level}")
 
         logger.log(level=level, msg=data.message.format(value=data.value))
-        return Greet.Output(value=data.value)
+        return self.output(value=data.value)
 
 
 class TestGreet(BaseTestComponent):
@@ -75,6 +78,6 @@ class TestGreet(BaseTestComponent):
     def test_greet_message(self, caplog):
         caplog.set_level(logging.WARNING)
         component = Greet()
-        results = component.run(Greet.Input(value=10, message="Hello, that's {value}", log_level="WARNING"))
-        assert results == Greet.Output(value=10)
+        results = component.run(component.input(value=10, message="Hello, that's {value}", log_level="WARNING"))
+        assert results == component.output(value=10)
         assert "Hello, that's 10" in caplog.text

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -4,9 +4,8 @@
 from typing import List, Union
 import builtins
 
-from dataclasses import dataclass
 
-from canals.component import component, VariadicComponentInput, ComponentOutput
+from canals.component import component
 from canals.testing import BaseTestComponent
 
 
@@ -26,18 +25,16 @@ class MergeLoop:
         self.expected_type = type_
         self.init_parameters = {"expected_type": type_.__name__}
 
-    @property
-    def input_type(self):
-        @dataclass
-        class Input(VariadicComponentInput):
+    @component.input(variadic=True)
+    def input(self):
+        class Input:
             values: List[self.expected_type]  # type: ignore
 
         return Input
 
-    @property
-    def output_type(self):
-        @dataclass
-        class Output(ComponentOutput):
+    @component.output
+    def output(self):
+        class Output:
             value: self.expected_type  # type: ignore
 
         return Output
@@ -50,8 +47,8 @@ class MergeLoop:
         """
         for v in data.values:
             if v is not None:
-                return self.output_type(value=v)
-        return self.output_type(value=None)
+                return self.output(value=v)
+        return self.output(value=None)
 
 
 class TestMergeLoop(BaseTestComponent):
@@ -68,25 +65,25 @@ class TestMergeLoop(BaseTestComponent):
 
     def test_merge_first(self):
         component = MergeLoop(expected_type=int)
-        results = component.run(component.input_type(5, None))
-        assert results.__dict__ == component.output_type(value=5).__dict__
+        results = component.run(component.input(5, None))
+        assert results == component.output(value=5)
 
     def test_merge_second(self):
         component = MergeLoop(expected_type=int)
-        results = component.run(component.input_type(None, 5))
-        assert results.__dict__ == component.output_type(value=5).__dict__
+        results = component.run(component.input(None, 5))
+        assert results == component.output(value=5)
 
     def test_merge_nones(self):
         component = MergeLoop(expected_type=int)
-        results = component.run(component.input_type(None, None, None))
-        assert results.__dict__ == component.output_type(value=None).__dict__
+        results = component.run(component.input(None, None, None))
+        assert results == component.output(value=None)
 
     def test_merge_one(self):
         component = MergeLoop(expected_type=int)
-        results = component.run(component.input_type(1))
-        assert results.__dict__ == component.output_type(value=1).__dict__
+        results = component.run(component.input(1))
+        assert results == component.output(value=1)
 
     def test_merge_one_none(self):
         component = MergeLoop(expected_type=int)
-        results = component.run(component.input_type())
-        assert results.__dict__ == component.output_type(value=None).__dict__
+        results = component.run(component.input())
+        assert results == component.output(value=None)

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -25,14 +25,14 @@ class MergeLoop:
         self.expected_type = type_
         self.init_parameters = {"expected_type": type_.__name__}
 
-    @component.input(variadic=True)
+    @component.input(variadic=True)  # type: ignore
     def input(self):
         class Input:
             values: List[self.expected_type]  # type: ignore
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             value: self.expected_type  # type: ignore

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -14,14 +14,14 @@ class Parity:
     Redirects the value, unchanged, along the 'even' connection if even, or along the 'odd' one if odd.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             even: Optional[int] = None

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -3,11 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 
-from dataclasses import dataclass
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -16,23 +14,29 @@ class Parity:
     Redirects the value, unchanged, along the 'even' connection if even, or along the 'odd' one if odd.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
 
-    @dataclass
-    class Output(ComponentOutput):
-        even: Optional[int] = None
-        odd: Optional[int] = None
+        return Input
 
-    def run(self, data: Input) -> Output:
+    @component.output
+    def output(self):
+        class Output:
+            even: Optional[int] = None
+            odd: Optional[int] = None
+
+        return Output
+
+    def run(self, data):
         """
         :param value: The value to check for parity
         """
         remainder = data.value % 2
         if remainder:
-            return Parity.Output(odd=data.value)
-        return Parity.Output(even=data.value)
+            return self.output(odd=data.value)
+        return self.output(even=data.value)
 
 
 class TestParity(BaseTestComponent):
@@ -41,7 +45,7 @@ class TestParity(BaseTestComponent):
 
     def test_parity(self):
         component = Parity()
-        results = component.run(Parity.Input(value=1))
-        assert results == Parity.Output(odd=1)
-        results = component.run(Parity.Input(value=2))
-        assert results == Parity.Output(even=2)
+        results = component.run(component.input(value=1))
+        assert results == component.output(odd=1)
+        results = component.run(component.input(value=2))
+        assert results == component.output(even=2)

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -17,7 +17,7 @@ class Remainder:
     the second output connection.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
@@ -33,7 +33,7 @@ class Remainder:
             "Output", fields=[(f"remainder_is_{val}", int, None) for val in range(divisor)]
         )
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         return self._output_type
 

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass, make_dataclass
+from dataclasses import make_dataclass
 
 import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -17,9 +17,12 @@ class Remainder:
     the second output connection.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
+
+        return Input
 
     def __init__(self, divisor: int = 2):
         if divisor == 0:
@@ -27,19 +30,19 @@ class Remainder:
         self.divisor = divisor
 
         self._output_type = make_dataclass(
-            "Output", fields=[(f"remainder_is_{val}", int, None) for val in range(divisor)], bases=(ComponentOutput,)
+            "Output", fields=[(f"remainder_is_{val}", int, None) for val in range(divisor)]
         )
 
-    @property
-    def output_type(self):
+    @component.output
+    def output(self):
         return self._output_type
 
-    def run(self, data: Input):
+    def run(self, data):
         """
         :param value: the value to check the remainder of.
         """
         remainder = data.value % self.divisor
-        output = self.output_type()
+        output = self.output()
         setattr(output, f"remainder_is_{remainder}", data.value)
         return output
 
@@ -53,13 +56,13 @@ class TestRemainder(BaseTestComponent):
 
     def test_remainder_default(self):
         component = Remainder()
-        results = component.run(Remainder.Input(value=3))
-        assert results == component.output_type(remainder_is_1=3)
+        results = component.run(component.input(value=3))
+        assert results == component.output(remainder_is_1=3)
 
     def test_remainder_with_divisor(self):
         component = Remainder(divisor=4)
-        results = component.run(Remainder.Input(value=3))
-        assert results == component.output_type(remainder_is_3=3)
+        results = component.run(component.input(value=3))
+        assert results == component.output(remainder_is_3=3)
 
     def test_remainder_zero(self):
         with pytest.raises(ValueError):

--- a/test/sample_components/test_repeat.py
+++ b/test/sample_components/test_repeat.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import TypeVar, Any, List
+from typing import List
 
-from dataclasses import make_dataclass, dataclass
+from dataclasses import make_dataclass
 
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -17,22 +16,23 @@ class Repeat:
     Repeats the input value on all outputs.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
+    @component.input
+    def input(self):
+        class Input:
+            value: int
+
+        return Input
 
     def __init__(self, outputs: List[str] = ["output_1", "output_2", "output_3"]):
         self.outputs = outputs
-        self._output_type = make_dataclass(
-            "Output", fields=[(val, int, None) for val in outputs], bases=(ComponentOutput,)
-        )
+        self._output_type = make_dataclass("Output", fields=[(val, int, None) for val in outputs])
 
-    @property
-    def output_type(self):
+    @component.output
+    def output(self):
         return self._output_type
 
-    def run(self, data: Input):
-        output_dataclass = self.output_type()
+    def run(self, data):
+        output_dataclass = self.output()
         for output in self.outputs:
             setattr(output_dataclass, output, data.value)
         return output_dataclass
@@ -47,12 +47,12 @@ class TestRepeat(BaseTestComponent):
 
     def test_repeat_default(self):
         component = Repeat()
-        results = component.run(Repeat.Input(value=10))
-        assert results == component.output_type(output_1=10, output_2=10, output_3=10)
+        results = component.run(component.input(value=10))
+        assert results == component.output(output_1=10, output_2=10, output_3=10)
         assert component.init_parameters == {}
 
     def test_repeat_init(self):
         component = Repeat(outputs=["one", "two"])
-        results = component.run(Repeat.Input(value=10))
-        assert results == component.output_type(one=10, two=10)
+        results = component.run(component.input(value=10))
+        assert results == component.output(one=10, two=10)
         assert component.init_parameters == {"outputs": ["one", "two"]}

--- a/test/sample_components/test_repeat.py
+++ b/test/sample_components/test_repeat.py
@@ -16,7 +16,7 @@ class Repeat:
     Repeats the input value on all outputs.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
@@ -27,7 +27,7 @@ class Repeat:
         self.outputs = outputs
         self._output_type = make_dataclass("Output", fields=[(val, int, None) for val in outputs])
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         return self._output_type
 

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -1,12 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
-
-import pytest
-
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -15,21 +11,27 @@ class Subtract:
     Compute the difference between two values.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        first_value: int
-        second_value: int
+    @component.input
+    def input(self):
+        class Input:
+            first_value: int
+            second_value: int
 
-    @dataclass
-    class Output(ComponentOutput):
-        difference: int
+        return Input
 
-    def run(self, data: Input) -> Output:
+    @component.output
+    def output(self):
+        class Output:
+            difference: int
+
+        return Output
+
+    def run(self, data):
         """
         :param first_value: name of the connection carrying the value to subtract from.
         :param second_value: name of the connection carrying the value to subtract.
         """
-        return Subtract.Output(difference=data.first_value - data.second_value)
+        return self.output(difference=data.first_value - data.second_value)
 
 
 class TestSubtract(BaseTestComponent):
@@ -38,6 +40,6 @@ class TestSubtract(BaseTestComponent):
 
     def test_subtract(self):
         component = Subtract()
-        results = component.run(Subtract.Input(first_value=10, second_value=7))
-        assert results == Subtract.Output(difference=3)
+        results = component.run(component.input(first_value=10, second_value=7))
+        assert results == component.output(difference=3)
         assert component.init_parameters == {}

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -11,7 +11,7 @@ class Subtract:
     Compute the difference between two values.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             first_value: int
@@ -19,7 +19,7 @@ class Subtract:
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             difference: int

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -14,14 +14,14 @@ class Sum:
     Sums the values of all the input connections together.
     """
 
-    @component.input(variadic=True)
+    @component.input(variadic=True)  # type: ignore
     def input(self):
         class Input:
             values: List[int]
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             total: int

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
-from dataclasses import dataclass
-
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, VariadicComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -17,16 +14,22 @@ class Sum:
     Sums the values of all the input connections together.
     """
 
-    @dataclass
-    class Input(VariadicComponentInput):
-        values: List[int]
+    @component.input(variadic=True)
+    def input(self):
+        class Input:
+            values: List[int]
 
-    @dataclass
-    class Output(ComponentOutput):
-        total: int
+        return Input
 
-    def run(self, data: Input) -> Output:
-        return Sum.Output(total=sum(data.values))
+    @component.output
+    def output(self):
+        class Output:
+            total: int
+
+        return Output
+
+    def run(self, data):
+        return self.output(total=sum(data.values))
 
 
 class TestSum(BaseTestComponent):
@@ -35,18 +38,18 @@ class TestSum(BaseTestComponent):
 
     def test_sum_no_values(self):
         component = Sum()
-        results = component.run(Sum.Input())
-        assert results == Sum.Output(total=0)
+        results = component.run(component.input())
+        assert results == component.output(total=0)
         assert component.init_parameters == {}
 
     def test_sum_one_value(self):
         component = Sum()
-        results = component.run(Sum.Input(10))
-        assert results == Sum.Output(total=10)
+        results = component.run(component.input(10))
+        assert results == component.output(total=10)
         assert component.init_parameters == {}
 
     def test_sum_few_values(self):
         component = Sum()
-        results = component.run(Sum.Input(10, 11, 12))
-        assert results == Sum.Output(total=33)
+        results = component.run(component.input(10, 11, 12))
+        assert results == component.output(total=33)
         assert component.init_parameters == {}

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 
-from dataclasses import dataclass
-
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.component import component, ComponentInput, ComponentOutput
+from canals.component import component
 
 
 @component
@@ -22,15 +19,21 @@ class Threshold:
     :param threshold: the number to compare the input value against. This is also a parameter.
     """
 
-    @dataclass
-    class Input(ComponentInput):
-        value: int
-        threshold: int = 10
+    @component.input
+    def input(self):
+        class Input:
+            value: int
+            threshold: int = 10
 
-    @dataclass
-    class Output(ComponentOutput):
-        above: int
-        below: int
+        return Input
+
+    @component.output
+    def output(self):
+        class Output:
+            above: int
+            below: int
+
+        return Output
 
     def __init__(self, threshold: Optional[int] = None):
         """
@@ -39,10 +42,10 @@ class Threshold:
         if threshold:
             self.defaults = {"threshold": threshold}
 
-    def run(self, data: Input) -> Output:
+    def run(self, data):
         if data.value < data.threshold:
-            return Threshold.Output(above=None, below=data.value)  # type: ignore
-        return Threshold.Output(above=data.value, below=None)  # type: ignore
+            return self.output(above=None, below=data.value)
+        return self.output(above=data.value, below=None)
 
 
 class TestThreshold(BaseTestComponent):
@@ -55,8 +58,8 @@ class TestThreshold(BaseTestComponent):
     def test_threshold(self):
         component = Threshold()
 
-        results = component.run(Threshold.Input(value=5, threshold=10))
-        assert results == Threshold.Output(above=None, below=5)
+        results = component.run(component.input(value=5, threshold=10))
+        assert results == component.output(above=None, below=5)
 
-        results = component.run(Threshold.Input(value=15, threshold=10))
-        assert results == Threshold.Output(above=15, below=None)
+        results = component.run(component.input(value=15, threshold=10))
+        assert results == component.output(above=15, below=None)

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -19,7 +19,7 @@ class Threshold:
     :param threshold: the number to compare the input value against. This is also a parameter.
     """
 
-    @component.input
+    @component.input  # type: ignore
     def input(self):
         class Input:
             value: int
@@ -27,7 +27,7 @@ class Threshold:
 
         return Input
 
-    @component.output
+    @component.output  # type: ignore
     def output(self):
         class Output:
             above: int


### PR DESCRIPTION
This PR changes how users can define a component input and output.

Previously the user could declare input and output in two different ways:

* Define in the component class an `Input` or `Output` inner class that inherits `BaseIODataclass`
* Define in the component class a `input_type` or `output_type` method that would return a dataclass that inherits `BaseIODataclass`

The new approach ditches the the `BaseIODataclass` hierarchy and relies on `@component.input` and `@component.output` decorators.

The user must now decorate a single method of their component to define its I/O, method name can be anything.

This also changes how some checks in `@component` are run.

Note: The `@component` docstrings have not been updated, I'll do it in later PRs as there are other changes to be made.

Another note: Most usages of `@component.input` and `@component.output` are marked as `# type: ignore` since `mypy` complains that `"Callable[[Any], Any]" has no attribute "input"  [attr-defined]`. We'll solve this in future PRs.