### PR TITLE
Change InputSocket taken_by field to sender

### DIFF
--- a/canals/pipeline/connections.py
+++ b/canals/pipeline/connections.py
@@ -33,7 +33,7 @@ def find_unambiguous_connection(
     possible_connections = [
         (out_sock, in_sock)
         for out_sock, in_sock in itertools.product(from_sockets, to_sockets)
-        if not in_sock.taken_by and out_sock.type == in_sock.type
+        if not in_sock.sender and out_sock.type == in_sock.type
     ]
 
     # No connections seem to be possible
@@ -75,7 +75,7 @@ def _connections_status(from_node: str, to_node: str, from_sockets: List[OutputS
     from_sockets_list = "\n".join([f" - {socket.name} ({socket.type.__name__})" for socket in from_sockets])
     to_sockets_list = "\n".join(
         [
-            f" - {socket.name} ({socket.type.__name__}, {'taken by '+socket.taken_by if socket.taken_by else 'available'})"
+            f" - {socket.name} ({socket.type.__name__}, {'sent by '+socket.sender if socket.sender else 'available'})"
             for socket in to_sockets
         ]
     )

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -211,12 +211,12 @@ class Pipeline:
                 f" - {to_node}.{to_socket.name}: {to_socket.type.__name__}\n"
             )
 
-        # Make sure the receiving socket is not taken - sending sockets can be connected as many times as needed,
+        # Make sure the receiving socket isn't already connected - sending sockets can be connected as many times as needed,
         # so they don't need this check
-        if to_socket.taken_by:
+        if to_socket.sender:
             raise PipelineConnectError(
                 f"Cannot connect '{from_node}.{from_socket.name}' with '{to_node}.{to_socket.name}': "
-                f"{to_node}.{to_socket.name} is already connected to {to_socket.taken_by}.\n"
+                f"{to_node}.{to_socket.name} is already connected to {to_socket.sender}.\n"
             )
 
         # Create the connection
@@ -224,9 +224,9 @@ class Pipeline:
         edge_key = f"{from_socket.name}/{to_socket.name}"
         self.graph.add_edge(from_node, to_node, key=edge_key, from_socket=from_socket, to_socket=to_socket)
 
-        # Mark the receiving socket as taken (unless is variadic - variadic sockets are never "taken")
+        # Set the sender of the receivering socket (unless is variadic - variadic sockets are never "taken")
         if not to_socket.variadic:
-            to_socket.taken_by = from_node
+            to_socket.sender = from_node
 
     def get_component(self, name: str) -> object:
         """

--- a/canals/pipeline/sockets.py
+++ b/canals/pipeline/sockets.py
@@ -23,7 +23,7 @@ class InputSocket:
     name: str
     type: type
     variadic: bool
-    taken_by: Optional[str] = None
+    sender: Optional[str] = None
 
 
 def find_input_sockets(component) -> Dict[str, InputSocket]:

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -20,7 +20,7 @@ def find_pipeline_inputs(graph: networkx.MultiDiGraph) -> Dict[str, List[InputSo
     input sockets, including all such sockets with default values.
     """
     return {
-        node: [socket for socket in data.get("input_sockets", {}).values() if not socket.taken_by]
+        node: [socket for socket in data.get("input_sockets", {}).values() if not socket.sender]
         for node, data in graph.nodes(data=True)
     }
 
@@ -101,6 +101,6 @@ def _validate_nodes_receive_only_expected_input(graph: networkx.MultiDiGraph, in
                     "Are you using the correct Input class?"
                 )
 
-            taken_by = graph.nodes[node]["input_sockets"][socket_name].taken_by
-            if taken_by:
-                raise ValueError(f"The input {socket_name} of {node} is already taken by node {taken_by}")
+            sender = graph.nodes[node]["input_sockets"][socket_name].sender
+            if sender:
+                raise ValueError(f"The input {socket_name} of {node} is already sent by node {sender}")

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -179,7 +179,7 @@ def test_validate_pipeline_input_only_expected_input_is_present():
     pipe.add_component("comp1", Double())
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
-    with pytest.raises(ValueError, match="The input value of comp2 is already taken by node comp1"):
+    with pytest.raises(ValueError, match="The input value of comp2 is already sent by node comp1"):
         pipe.run({"comp1": Double().input(value=1), "comp2": Double().input(value=1)})
 
 


### PR DESCRIPTION
The current field `taken_by` is confusing as it's not clear whether it refers to the receving or sender node.
We change it to `sender` so that's it's clear what it refers to.