### PR TITLE
Handle components with partial input

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -202,6 +202,7 @@ def component(class_):
     # Those are necessary to implement Components that can run with partial input, this gives us
     # the possibility to have cycles in Pipelines.
     class_.__canals_optional_inputs__ = property(_optional_inputs)
+    class_.__canals_mandatory_inputs__ = property(_mandatory_inputs)
 
     # Check that the run method respects all constraints
     _check_run_signature(class_)
@@ -299,3 +300,12 @@ def _optional_inputs(self) -> List[str]:
     This is meant to be set as a property in a Component.
     """
     return [f.name for f in fields(self.__canals_input__) if _is_optional(f)]
+
+
+# TODO: Remember to set the self type to Component when we create its Protocol
+def _mandatory_inputs(self) -> List[str]:
+    """
+    Return all field names of self that don't have an Optional type.
+    This is meant to be set as a property in a Component.
+    """
+    return [f.name for f in fields(self.__canals_input__) if not _is_optional(f)]

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -373,7 +373,7 @@ class Pipeline:
                 continue
 
             if action == "remove":
-                # This component has no reason of being in the run queue and we need to remove it. For example, this can happen to components that are connected to skipped branches of the pipeline. 
+                # This component has no reason of being in the run queue and we need to remove it. For example, this can happen to components that are connected to skipped branches of the pipeline.
                 continue
 
             # **** RUN THE NODE ****

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -373,7 +373,7 @@ class Pipeline:
                 continue
 
             if action == "remove":
-                # This component has no reason of being in the run queue, it's best if we remove it
+                # This component has no reason of being in the run queue and we need to remove it. For example, this can happen to components that are connected to skipped branches of the pipeline. 
                 continue
 
             # **** RUN THE NODE ****
@@ -556,7 +556,7 @@ class Pipeline:
         if mandatory_input_sockets == received_input_sockets and skipped_optional_input_sockets.issubset(
             optional_input_sockets
         ):
-            # We received all of the inputs we need and some optional inputs have not been skipped
+            # We received all of the inputs we need, but some optional inputs have not been run or skipped yet
             logger.debug(
                 "Component '%s' is waiting. All mandatory inputs received, some optional are not skipped: %s",
                 name,

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -524,33 +524,30 @@ class Pipeline:
         ##############
         # RUN CHECKS #
         ##############
-        if mandatory_input_sockets.issubset(received_input_sockets):
-            # We received all mandatory inputs
-            if not optional_input_sockets:
-                # We have no optional inputs
-                logger.debug("Component '%s' is ready to run. All mandatory inputs received.", name)
-                return "run"
-            if skipped_optional_input_sockets == optional_input_sockets:
-                # All optional inputs are skipped
-                logger.debug(
-                    "Component '%s' is ready to run. All mandatory inputs received, all optional inputs are skipped.",
-                    name,
-                )
-                return "run"
-            if input_sockets == received_input_sockets | mandatory_input_sockets | skipped_optional_input_sockets:
-                # We received part of the optional inputs, the rest are skipped
-                logger.debug(
-                    "Component '%s' is ready to run. All mandatory inputs received, skipped some optional inputs: %s",
-                    name,
-                    skipped_optional_input_sockets,
-                )
-                return "run"
+        if (
+            mandatory_input_sockets.issubset(received_input_sockets)
+            and input_sockets == received_input_sockets | mandatory_input_sockets | skipped_optional_input_sockets
+        ):
+            # We received all mandatory inputs and:
+            #   * There are no optional inputs or
+            #   * All optional inputs are skipped or
+            #   * We received part of the optional inputs, the rest are skipped
+            if logger.level == logging.DEBUG:
+                if not optional_input_sockets:
+                    logger.debug("Component '%s' is ready to run. All mandatory inputs received.", name)
+                else:
+                    logger.debug(
+                        "Component '%s' is ready to run. All mandatory inputs received, skipped optional inputs: %s",
+                        name,
+                        skipped_optional_input_sockets,
+                    )
+            return "run"
 
         if set(input_components.values()).issubset(received_input_sockets):
             # We have data from each connected input component.
-            # We reach this when the current component is the first of the pipeline or when
-            # it has defaults and all its input components have run.
-            logger.debug("Component '%s' is ready to run: all expected inputs were received.", name)
+            # We reach this when the current component is the first of the pipeline or
+            # when it has defaults and all its input components have run.
+            logger.debug("Component '%s' is ready to run. All expected inputs were received.", name)
             return "run"
 
         ###############

--- a/test/pipelines/integration/test_complex_pipeline.py
+++ b/test/pipelines/integration/test_complex_pipeline.py
@@ -27,7 +27,7 @@ def test_complex_pipeline(tmp_path):
     loop_merger = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])
     summer = Sum(inputs=["in_1", "in_2", "in_3"])
 
-    pipeline = Pipeline(max_loops_allowed=13)
+    pipeline = Pipeline(max_loops_allowed=2)
     pipeline.add_component("greet_first", Greet(message="Hello, the value is {value}."))
     pipeline.add_component("accumulate_1", accumulate)
     pipeline.add_component("add_two", AddFixedValue(add=2))

--- a/test/pipelines/integration/test_complex_pipeline.py
+++ b/test/pipelines/integration/test_complex_pipeline.py
@@ -5,8 +5,6 @@ from pathlib import Path
 from pprint import pprint
 import logging
 
-import pytest
-
 from canals.pipeline import Pipeline
 from test.sample_components import (
     Accumulate,
@@ -24,13 +22,12 @@ from test.sample_components import (
 logging.basicConfig(level=logging.DEBUG)
 
 
-@pytest.mark.skip("This is failing cause we removed variadics")
 def test_complex_pipeline(tmp_path):
     accumulate = Accumulate()
     loop_merger = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])
     summer = Sum(inputs=["in_1", "in_2", "in_3"])
 
-    pipeline = Pipeline(max_loops_allowed=4)
+    pipeline = Pipeline(max_loops_allowed=13)
     pipeline.add_component("greet_first", Greet(message="Hello, the value is {value}."))
     pipeline.add_component("accumulate_1", accumulate)
     pipeline.add_component("add_two", AddFixedValue(add=2))

--- a/test/pipelines/integration/test_double_loop_pipeline.py
+++ b/test/pipelines/integration/test_double_loop_pipeline.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import *
+from pathlib import Path
+from pprint import pprint
+
+from canals.pipeline import Pipeline
+from test.sample_components import Accumulate, AddFixedValue, Threshold, MergeLoop
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def test_pipeline(tmp_path):
+    accumulator = Accumulate()
+    merge_loop = MergeLoop(expected_type=int, inputs=["in_1", "in_2", "in_3"])
+
+    pipeline = Pipeline(max_loops_allowed=10)
+    pipeline.add_component("add_one", AddFixedValue(add=1))
+    pipeline.add_component("merge", merge_loop)
+    pipeline.add_component("below_10", Threshold(threshold=10))
+    pipeline.add_component("below_5", Threshold(threshold=5))
+    pipeline.add_component("add_three", AddFixedValue(add=3))
+    pipeline.add_component("accumulator", accumulator)
+    pipeline.add_component("add_two", AddFixedValue(add=2))
+
+    pipeline.connect("add_one", "merge.in_1")
+    pipeline.connect("merge", "below_10")
+    pipeline.connect("below_10.below", "accumulator")
+    pipeline.connect("accumulator", "below_5")
+    pipeline.connect("below_5.above", "add_three.value")
+    pipeline.connect("below_5.below", "merge.in_2")
+    pipeline.connect("add_three", "merge.in_3")
+    pipeline.connect("below_10.above", "add_two.value")
+
+    pipeline.draw(tmp_path / "double_loop_pipeline.png")
+
+    results = pipeline.run({"add_one": AddFixedValue().input(value=3)})
+    pprint(results)
+    print("accumulator: ", accumulator.state)
+
+    assert results == {"add_two": AddFixedValue().output(value=13)}
+    assert accumulator.state == 8
+
+
+if __name__ == "__main__":
+    test_pipeline(Path(__file__).parent)

--- a/test/pipelines/integration/test_looping_pipeline.py
+++ b/test/pipelines/integration/test_looping_pipeline.py
@@ -5,8 +5,6 @@ from typing import *
 from pathlib import Path
 from pprint import pprint
 
-import pytest
-
 from canals.pipeline import Pipeline
 from test.sample_components import Accumulate, AddFixedValue, Threshold, MergeLoop
 
@@ -15,7 +13,6 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 
-@pytest.mark.skip("This is failing cause we removed variadics")
 def test_pipeline(tmp_path):
     accumulator = Accumulate()
     merge_loop = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])

--- a/test/pipelines/integration/test_variable_decision_and_merge_pipeline.py
+++ b/test/pipelines/integration/test_variable_decision_and_merge_pipeline.py
@@ -5,26 +5,12 @@ import logging
 from pathlib import Path
 from pprint import pprint
 
-import pytest
-
 from canals.pipeline import Pipeline
 from test.sample_components import AddFixedValue, Remainder, Double, Sum
 
 logging.basicConfig(level=logging.DEBUG)
 
 
-# This pipeline is a problem now.
-# Components with variadics had a peculiarity, they always run even if they
-# didn't receive all their inputs.
-# This pipeline used to run, but now it doesn't as "sum" doesn't
-# receive all its inputs.
-# This happens because "parity" only returns
-# ouput on remainder_is_0, while remainder_is_1 is None.
-# This causes only "add_ten" to receive input, while "double" and "add_four"
-# never do and are skipped.
-# Since those components are never run "sum" doesn't receive all its inputs
-# and in the end is skipped.
-@pytest.mark.skip(reason="Since we removed variadics this pipeline doesn't return any output")
 def test_pipeline(tmp_path):
     add_one = AddFixedValue()
     summer = Sum(inputs=["in_1", "in_2", "in_3", "in_4"])

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import builtins
-from typing import List, Union
+from typing import List, Union, Optional
 from dataclasses import make_dataclass, is_dataclass, asdict
 
 from canals.component import component
@@ -21,7 +21,9 @@ class MergeLoop:
         else:
             self.expected_type = expected_type
         self.init_parameters = {"expected_type": self.expected_type.__name__}
-        self._input = make_dataclass("Input", fields=[(f, self.expected_type, None) for f in inputs])
+        # mypy complains that we can't Optional is not a type, so we ignore the error
+        # cause we consider this to be correct
+        self._input = make_dataclass("Input", fields=[(f, Optional[self.expected_type]) for f in inputs])  # type: ignore
 
     @component.input  # type: ignore
     def input(self):

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
 from dataclasses import make_dataclass, asdict, is_dataclass
 
 from canals.testing import BaseTestComponent
@@ -14,7 +15,9 @@ class Sum:
     """
 
     def __init__(self, inputs=["value_1"]) -> None:
-        self._input = make_dataclass("Input", fields=[(f, int) for f in inputs])
+        # mypy complains that we can't Optional is not a type, so we ignore the error
+        # cause we consider this to be correct
+        self._input = make_dataclass("Input", fields=[(f, Optional[int]) for f in inputs])  # type: ignore
 
     @component.input  # type: ignore
     def input(self):
@@ -30,7 +33,7 @@ class Sum:
     def run(self, data):
         values = []
         if is_dataclass(data):
-            values = asdict(data).values()
+            values = [n for n in asdict(data).values() if n]
         return self.output(total=sum(values))
 
 


### PR DESCRIPTION
Component's input dataclasses that have `Optional` fields are now treated as partials.

If those `Optional` fields are skipped and never received the component will run anyway, it will first wait to be sure that those inputs are actually skipped and will never be received.

This enables us to have cycles in Pipeline.

Closes #27 