### PR TITLE
Make component decorator a class

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -231,6 +231,9 @@ class _Component:
         # Makes sure the self.defaults dictionary is always present
         class_.__init__ = init_defaults(class_.__init__)
 
+        if class_.__name__ in self.registry:
+            logger.error("Component %s is already registered")
+
         self.registry[class_.__name__] = class_
         logger.debug("Registered Component %s", class_)
 

--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -232,7 +232,12 @@ class _Component:
         class_.__init__ = init_defaults(class_.__init__)
 
         if class_.__name__ in self.registry:
-            logger.error("Component %s is already registered")
+            logger.error(
+                "Component %s is already registered. Previous imported from '%s', new imported from '%s'",
+                class_.__name__,
+                self.registry[class_.__name__],
+                class_,
+            )
 
         self.registry[class_.__name__] = class_
         logger.debug("Registered Component %s", class_)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from canals.component import component, ComponentError
@@ -27,6 +25,7 @@ def test_correct_declaration():
 
     # Verifies also instantiation works with no issues
     assert MockComponent()
+    assert component.registry["MockComponent"] == MockComponent
 
 
 def test_input_required():


### PR DESCRIPTION
`component` is now an instance of the `_Component` class.
This makes it easier set `component.input` and `component.output` property, this also enables autocompletion.

I also added a registry to keep track of all classes marked with `@component`.

Closes #30 