### PR TITLE
Simplify public interface imports

### DIFF
--- a/canals/__init__.py
+++ b/canals/__init__.py
@@ -2,3 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from canals.__about__ import __version__
+
+from canals.component import component, Component
+from canals.pipeline.pipeline import Pipeline
+from canals.pipeline.save_load import (
+    save_pipelines,
+    load_pipelines,
+    marshal_pipelines,
+    unmarshal_pipelines,
+)

--- a/test/_helpers.py
+++ b/test/_helpers.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any
-from canals.component import component
+
+from canals import component
 
 
 def make_component(input=Any, output=Any):

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,6 +1,6 @@
 import pytest
 
-from canals.component import component
+from canals import component
 from canals.errors import ComponentError
 
 

--- a/test/pipelines/unit/test_connections.py
+++ b/test/pipelines/unit/test_connections.py
@@ -9,8 +9,7 @@ from pathlib import Path
 import pytest
 
 from canals.errors import PipelineConnectError
-from canals.pipeline import Pipeline, PipelineConnectError
-from canals.component import component
+from canals import Pipeline, component
 from canals.pipeline.sockets import find_input_sockets, find_output_sockets
 from canals.pipeline.connections import find_unambiguous_connection, get_socket_type_desc
 

--- a/test/pipelines/unit/test_draw.py
+++ b/test/pipelines/unit/test_draw.py
@@ -10,8 +10,8 @@ import pytest
 import requests
 
 from canals.pipeline import Pipeline
-from canals.errors import PipelineDrawingError
 from canals.draw import draw, convert
+from canals.errors import PipelineDrawingError
 
 from test.sample_components import Double
 

--- a/test/pipelines/unit/test_input_sockets.py
+++ b/test/pipelines/unit/test_input_sockets.py
@@ -4,7 +4,7 @@
 import typing
 from typing import List, Optional, Union, Set, Sequence, Iterable, Dict, Mapping, Tuple
 
-from canals.component import component
+from canals import component
 from canals.pipeline.sockets import (
     find_input_sockets,
     InputSocket,

--- a/test/pipelines/unit/test_output_sockets.py
+++ b/test/pipelines/unit/test_output_sockets.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Optional, Union, Set, Sequence, Iterable, Dict, Mapping, Tuple
 
-from canals.component import component
+from canals import component
 from canals.pipeline.sockets import (
     find_output_sockets,
     OutputSocket,

--- a/test/pipelines/unit/test_pipeline.py
+++ b/test/pipelines/unit/test_pipeline.py
@@ -5,7 +5,8 @@
 from typing import List
 import pytest
 
-from canals.pipeline import Pipeline, PipelineMaxLoops
+from canals import Pipeline
+from canals.errors import PipelineMaxLoops
 from test.sample_components import AddFixedValue, Threshold, MergeLoop
 
 import logging

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -2,7 +2,8 @@ from typing import Optional
 
 import pytest
 
-from canals.pipeline import Pipeline, PipelineValidationError
+from canals.pipeline import Pipeline
+from canals.errors import PipelineValidationError
 from canals.pipeline.sockets import InputSocket, OutputSocket
 from canals.pipeline.validation import find_pipeline_inputs, find_pipeline_outputs
 

--- a/test/sample_components/test_accumulate.py
+++ b/test/sample_components/test_accumulate.py
@@ -6,7 +6,7 @@ import sys
 import builtins
 from importlib import import_module
 
-from canals.component import component
+from canals import component
 from canals.testing import BaseTestComponent
 
 

--- a/test/sample_components/test_add_value.py
+++ b/test/sample_components/test_add_value.py
@@ -4,7 +4,7 @@
 from typing import Optional
 
 
-from canals.component import component
+from canals import component
 from canals.testing.test_component import BaseTestComponent
 
 

--- a/test/sample_components/test_concatenate.py
+++ b/test/sample_components/test_concatenate.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Union, List
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from canals.component import component
+from canals import component
 from canals.testing import BaseTestComponent
 
 

--- a/test/sample_components/test_greet.py
+++ b/test/sample_components/test_greet.py
@@ -5,8 +5,8 @@ from typing import Optional
 import logging
 
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 logger = logging.getLogger(__name__)

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -5,7 +5,7 @@ import builtins
 from typing import List, Union, Optional
 from dataclasses import make_dataclass, is_dataclass, asdict
 
-from canals.component import component
+from canals import component
 from canals.testing import BaseTestComponent
 
 

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -4,8 +4,8 @@
 from typing import Optional
 
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -5,8 +5,8 @@ from dataclasses import make_dataclass
 
 import pytest
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_repeat.py
+++ b/test/sample_components/test_repeat.py
@@ -6,8 +6,8 @@ from typing import List
 from dataclasses import make_dataclass
 
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -4,8 +4,8 @@
 from typing import Optional
 from dataclasses import make_dataclass, asdict, is_dataclass
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -4,8 +4,8 @@
 from typing import Optional
 
 
+from canals import component
 from canals.testing import BaseTestComponent
-from canals.component import component
 
 
 @component

--- a/test/test_save_load.py
+++ b/test/test_save_load.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from canals.pipeline import Pipeline, marshal_pipelines, unmarshal_pipelines
+from canals import Pipeline, marshal_pipelines, unmarshal_pipelines
 from test.sample_components import AddFixedValue, Double
 
 import logging


### PR DESCRIPTION
Simplify imports of public interface.

Previous:

```
from canals.component import component
from canals.pipeline import Pipeline
```

Now:

```
from canals import component, Pipeline
```