### PR TITLE
Move draw in pipeline module and clearly define public interface

### DIFF
--- a/canals/pipeline/connections.py
+++ b/canals/pipeline/connections.py
@@ -13,7 +13,7 @@ from canals.pipeline.sockets import InputSocket, OutputSocket
 logger = logging.getLogger(__name__)
 
 
-def parse_connection_name(connection: str) -> Tuple[str, Optional[str]]:
+def _parse_connection_name(connection: str) -> Tuple[str, Optional[str]]:
     """
     Returns component-connection pairs from a connect_to/from string
     """
@@ -62,7 +62,7 @@ def _types_are_compatible(sender, receiver):  # pylint: disable=too-many-return-
     return all(_types_are_compatible(*args) for args in zip(sender_args, receiver_args))
 
 
-def find_unambiguous_connection(
+def _find_unambiguous_connection(
     sender_node: str, receiver_node: str, sender_sockets: List[OutputSocket], receiver_sockets: List[InputSocket]
 ) -> Tuple[OutputSocket, InputSocket]:
     """
@@ -136,13 +136,13 @@ def _connections_status(
     """
     sender_sockets_entries = []
     for sender_socket in sender_sockets:
-        socket_types = get_socket_type_desc(sender_socket.type)
+        socket_types = _get_socket_type_desc(sender_socket.type)
         sender_sockets_entries.append(f" - {sender_socket.name} ({socket_types})")
     sender_sockets_list = "\n".join(sender_sockets_entries)
 
     receiver_sockets_entries = []
     for receiver_socket in receiver_sockets:
-        socket_types = get_socket_type_desc(receiver_socket.type)
+        socket_types = _get_socket_type_desc(receiver_socket.type)
         receiver_sockets_entries.append(
             f" - {receiver_socket.name} ({socket_types}), "
             f"{'sent by '+receiver_socket.sender if receiver_socket.sender else 'available'}"
@@ -152,7 +152,7 @@ def _connections_status(
     return f"'{sender_node}':\n{sender_sockets_list}\n'{receiver_node}':\n{receiver_sockets_list}"
 
 
-def get_socket_type_desc(type_):
+def _get_socket_type_desc(type_):
     """
     Assembles a readable representation of the type of a connection. Can handle primitive types, classes, and
     arbitrarily nested structures of types from the typing module.
@@ -189,5 +189,5 @@ def get_socket_type_desc(type_):
     else:
         type_name = type_.__name__
 
-    subtypes = ", ".join([get_socket_type_desc(subtype) for subtype in args if subtype is not type(None)])
+    subtypes = ", ".join([_get_socket_type_desc(subtype) for subtype in args if subtype is not type(None)])
     return f"{type_name}[{subtypes}]"

--- a/canals/pipeline/draw/__init__.py
+++ b/canals/pipeline/draw/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from canals.draw.draw import draw, convert, convert_for_debug, RenderingEngines
+from canals.pipeline.draw.draw import _draw, _convert, _convert_for_debug, RenderingEngines

--- a/canals/pipeline/draw/draw.py
+++ b/canals/pipeline/draw/draw.py
@@ -8,16 +8,16 @@ from pathlib import Path
 
 import networkx
 
-from canals.pipeline.validation import find_pipeline_inputs, find_pipeline_outputs
-from canals.draw.graphviz import to_agraph
-from canals.draw.mermaid import to_mermaid_image, to_mermaid_text
+from canals.pipeline.validation import _find_pipeline_inputs, _find_pipeline_outputs
+from canals.pipeline.draw.graphviz import _to_agraph
+from canals.pipeline.draw.mermaid import _to_mermaid_image, _to_mermaid_text
 
 
 logger = logging.getLogger(__name__)
 RenderingEngines = Literal["graphviz", "mermaid-img", "mermaid-text"]
 
 
-def draw(
+def _draw(
     graph: networkx.MultiDiGraph,
     path: Path,
     engine: RenderingEngines = "mermaid-img",
@@ -26,7 +26,7 @@ def draw(
     """
     Renders the pipeline graph and saves it to file.
     """
-    converted_graph = convert(graph=graph, engine=engine, style_map=style_map)
+    converted_graph = _convert(graph=graph, engine=engine, style_map=style_map)
 
     if engine == "graphviz":
         converted_graph.draw(path)
@@ -45,17 +45,17 @@ def draw(
     logger.debug("Pipeline diagram saved at %s", path)
 
 
-def convert_for_debug(
+def _convert_for_debug(
     graph: networkx.MultiDiGraph,
 ) -> Any:
     """
     Renders the pipeline graph with additional debug information into a text file that Mermaid can later render.
     """
     graph = _prepare_for_drawing(graph=graph, style_map={})
-    return to_mermaid_text(graph=graph)
+    return _to_mermaid_text(graph=graph)
 
 
-def convert(
+def _convert(
     graph: networkx.MultiDiGraph,
     engine: RenderingEngines = "mermaid-img",
     style_map: Optional[Dict[str, str]] = None,
@@ -66,13 +66,13 @@ def convert(
     graph = _prepare_for_drawing(graph=graph, style_map=style_map or {})
 
     if engine == "graphviz":
-        return to_agraph(graph=graph)
+        return _to_agraph(graph=graph)
 
     if engine == "mermaid-img":
-        return to_mermaid_image(graph=graph)
+        return _to_mermaid_image(graph=graph)
 
     if engine == "mermaid-text":
-        return to_mermaid_text(graph=graph)
+        return _to_mermaid_text(graph=graph)
 
     raise ValueError(f"Unknown rendering engine '{engine}'. Choose one from: {get_args(RenderingEngines)}.")
 
@@ -93,7 +93,7 @@ def _prepare_for_drawing(graph: networkx.MultiDiGraph, style_map: Dict[str, str]
 
     # Draw the inputs
     graph.add_node("input")
-    for node, in_sockets in find_pipeline_inputs(graph).items():
+    for node, in_sockets in _find_pipeline_inputs(graph).items():
         for in_socket in in_sockets:
             node_instance = graph.nodes[node]["instance"]
             socket_has_default = in_socket.name in node_instance.defaults
@@ -104,7 +104,7 @@ def _prepare_for_drawing(graph: networkx.MultiDiGraph, style_map: Dict[str, str]
 
     # Draw the outputs
     graph.add_node("output")
-    for node, out_sockets in find_pipeline_outputs(graph).items():
+    for node, out_sockets in _find_pipeline_outputs(graph).items():
         for out_socket in out_sockets:
             graph.add_edge(node, "output", label=out_socket.name)
 

--- a/canals/pipeline/draw/graphviz.py
+++ b/canals/pipeline/draw/graphviz.py
@@ -11,7 +11,7 @@ from networkx.drawing.nx_agraph import to_agraph as nx_to_agraph
 logger = logging.getLogger(__name__)
 
 
-def to_agraph(graph: networkx.MultiDiGraph):
+def _to_agraph(graph: networkx.MultiDiGraph):
     """
     Renders a pipeline graph using PyGraphViz. You need to install it and all its system dependencies for it to work.
     """

--- a/canals/pipeline/draw/mermaid.py
+++ b/canals/pipeline/draw/mermaid.py
@@ -25,11 +25,11 @@ linkStyle default stroke-width:2px,stroke-dasharray: 5 5;
 """
 
 
-def to_mermaid_image(graph: networkx.MultiDiGraph):
+def _to_mermaid_image(graph: networkx.MultiDiGraph):
     """
     Renders a pipeline using Mermaid (hosted version at 'https://mermaid.ink'). Requires Internet access.
     """
-    graph_as_text = to_mermaid_text(graph=graph)
+    graph_as_text = _to_mermaid_text(graph=graph)
     num_solid_arrows = len(graph.edges) - len(graph.in_edges("output")) - len(graph.out_edges("input"))
     solid_arrows = "\n".join([f"linkStyle {i} stroke-width:2px;" for i in range(num_solid_arrows)])
 
@@ -61,7 +61,7 @@ def to_mermaid_image(graph: networkx.MultiDiGraph):
     return resp.content
 
 
-def to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
+def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
     """
     Converts a Networkx graph into Mermaid syntax. The output of this function can be used in the documentation
     with `mermaid` codeblocks and it will be automatically rendered.

--- a/canals/pipeline/sockets.py
+++ b/canals/pipeline/sockets.py
@@ -23,14 +23,14 @@ class InputSocket:
     sender: Optional[str] = None
 
 
-def find_input_sockets(component) -> Dict[str, InputSocket]:
+def _find_input_sockets(component) -> Dict[str, InputSocket]:
     """
     Find a component's input sockets.
     """
     return {f.name: InputSocket(name=f.name, type=f.type) for f in fields(component.__canals_input__)}
 
 
-def find_output_sockets(component) -> Dict[str, OutputSocket]:
+def _find_output_sockets(component) -> Dict[str, OutputSocket]:
     """
     Find a component's output sockets.
     """

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -14,7 +14,7 @@ from canals.pipeline.sockets import InputSocket, OutputSocket
 logger = logging.getLogger(__name__)
 
 
-def find_pipeline_inputs(graph: networkx.MultiDiGraph) -> Dict[str, List[InputSocket]]:
+def _find_pipeline_inputs(graph: networkx.MultiDiGraph) -> Dict[str, List[InputSocket]]:
     """
     Collect components that have disconnected input sockets. Note that this method returns *ALL* disconnected
     input sockets, including all such sockets with default values.
@@ -25,7 +25,7 @@ def find_pipeline_inputs(graph: networkx.MultiDiGraph) -> Dict[str, List[InputSo
     }
 
 
-def find_pipeline_outputs(graph) -> Dict[str, List[OutputSocket]]:
+def _find_pipeline_outputs(graph) -> Dict[str, List[OutputSocket]]:
     """
     Collect components that have disconnected output sockets. They define the pipeline output.
     """
@@ -36,12 +36,12 @@ def find_pipeline_outputs(graph) -> Dict[str, List[OutputSocket]]:
     }
 
 
-def validate_pipeline_input(graph: networkx.MultiDiGraph, input_values: Dict[str, Any]) -> Dict[str, Any]:
+def _validate_pipeline_input(graph: networkx.MultiDiGraph, input_values: Dict[str, Any]) -> Dict[str, Any]:
     """
     Make sure the pipeline is properly built and that the input received makes sense.
     Returns the input values, validated and updated at need.
     """
-    if not any(sockets for sockets in find_pipeline_inputs(graph).values()):
+    if not any(sockets for sockets in _find_pipeline_inputs(graph).values()):
         raise PipelineValidationError("This pipeline has no inputs.")
 
     # Make sure the input keys are all nodes of the pipeline
@@ -63,7 +63,7 @@ def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_va
     Make sure all the inputs nodes are receiving all the values they need, either from the Pipeline's input or from
     other nodes.
     """
-    valid_inputs = find_pipeline_inputs(graph)
+    valid_inputs = _find_pipeline_inputs(graph)
     for node, sockets in valid_inputs.items():
         for socket in sockets:
             node_instance = graph.nodes[node]["instance"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ def mock_mermaid_request(test_files):
     """
     Prevents real requests to https://mermaid.ink/
     """
-    with patch("canals.draw.mermaid.requests.get") as mock_get:
+    with patch("canals.pipeline.draw.mermaid.requests.get") as mock_get:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.content = open(test_files / "mermaid_mock" / "test_response.png", "rb").read()

--- a/test/pipelines/unit/test_connections.py
+++ b/test/pipelines/unit/test_connections.py
@@ -10,8 +10,8 @@ import pytest
 
 from canals.errors import PipelineConnectError
 from canals import Pipeline, component
-from canals.pipeline.sockets import find_input_sockets, find_output_sockets
-from canals.pipeline.connections import find_unambiguous_connection, get_socket_type_desc
+from canals.pipeline.sockets import _find_input_sockets, _find_output_sockets
+from canals.pipeline.connections import _find_unambiguous_connection, _get_socket_type_desc
 
 from test.sample_components import AddFixedValue, Greet
 from test._helpers import make_component
@@ -479,11 +479,11 @@ def test_find_unambiguous_connection_many_connections_possible_no_name_matches()
  - value3 (str), available"""
     )
     with pytest.raises(PipelineConnectError, match=expected_message):
-        find_unambiguous_connection(
+        _find_unambiguous_connection(
             sender_node="comp1",
             receiver_node="comp2",
-            sender_sockets=find_output_sockets(Component1()).values(),
-            receiver_sockets=find_input_sockets(Component2()).values(),
+            sender_sockets=_find_output_sockets(Component1()).values(),
+            receiver_sockets=_find_input_sockets(Component2()).values(),
         )
 
 
@@ -553,4 +553,4 @@ def test_find_unambiguous_connection_many_connections_possible_no_name_matches()
     ],
 )
 def test_get_socket_type_desc(type_, repr):
-    assert get_socket_type_desc(type_) == repr
+    assert _get_socket_type_desc(type_) == repr

--- a/test/pipelines/unit/test_draw.py
+++ b/test/pipelines/unit/test_draw.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 
 from canals.pipeline import Pipeline
-from canals.draw import draw, convert
+from canals.pipeline.draw import _draw, _convert
 from canals.errors import PipelineDrawingError
 
 from test.sample_components import Double
@@ -24,7 +24,7 @@ def test_draw_pygraphviz(tmp_path, test_files):
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
 
-    draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="graphviz")
+    _draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="graphviz")
     assert os.path.exists(tmp_path / "test_pipe.jpg")
     assert filecmp.cmp(tmp_path / "test_pipe.jpg", test_files / "pipeline_draw" / "pygraphviz.jpg")
 
@@ -36,7 +36,7 @@ def test_draw_mermaid_img(tmp_path, test_files):
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="mermaid-img")
+    _draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="mermaid-img")
     assert os.path.exists(tmp_path / "test_pipe.jpg")
     assert filecmp.cmp(tmp_path / "test_pipe.jpg", test_files / "mermaid_mock" / "test_response.png")
 
@@ -48,7 +48,7 @@ def test_draw_mermaid_img_failing_request(tmp_path):
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    with patch("canals.draw.mermaid.requests.get") as mock_get:
+    with patch("canals.pipeline.draw.mermaid.requests.get") as mock_get:
 
         def raise_for_status(self):
             raise requests.HTTPError()
@@ -60,7 +60,7 @@ def test_draw_mermaid_img_failing_request(tmp_path):
         mock_get.return_value = mock_response
 
         with pytest.raises(PipelineDrawingError, match="There was an issue with https://mermaid.ink/"):
-            draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="mermaid-img")
+            _draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="mermaid-img")
 
 
 def test_draw_mermaid_txt(tmp_path):
@@ -70,7 +70,7 @@ def test_draw_mermaid_txt(tmp_path):
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    draw(pipe.graph, tmp_path / "test_pipe.md", engine="mermaid-text")
+    _draw(pipe.graph, tmp_path / "test_pipe.md", engine="mermaid-text")
     assert os.path.exists(tmp_path / "test_pipe.md")
     assert (
         open(tmp_path / "test_pipe.md", "r").read()
@@ -88,7 +88,7 @@ def test_draw_unknown_engine(tmp_path):
     pipe.connect("comp2", "comp1")
 
     with pytest.raises(ValueError, match="Unknown rendering engine 'unknown'"):
-        draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="unknown")
+        _draw(pipe.graph, tmp_path / "test_pipe.jpg", engine="unknown")
 
 
 def test_convert_unknown_engine(tmp_path):
@@ -99,4 +99,4 @@ def test_convert_unknown_engine(tmp_path):
     pipe.connect("comp2", "comp1")
 
     with pytest.raises(ValueError, match="Unknown rendering engine 'unknown'"):
-        convert(pipe.graph, engine="unknown")
+        _convert(pipe.graph, engine="unknown")

--- a/test/pipelines/unit/test_input_sockets.py
+++ b/test/pipelines/unit/test_input_sockets.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union, Set, Sequence, Iterable, Dict, Mapping
 
 from canals import component
 from canals.pipeline.sockets import (
-    find_input_sockets,
+    _find_input_sockets,
     InputSocket,
 )
 
@@ -32,7 +32,7 @@ def test_find_input_sockets_one_regular_builtin_type_input():
             return self.output(output_value=data.input_value)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {"input_value": InputSocket(name="input_value", type=int)}
     assert sockets == expected
 
@@ -60,7 +60,7 @@ def test_find_input_sockets_many_regular_builtin_type_inputs():
             return self.output(output_value=data.int_value)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "int_value": InputSocket(name="int_value", type=int),
         "str_value": InputSocket(name="str_value", type=str),
@@ -93,7 +93,7 @@ def test_find_input_sockets_one_regular_object_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {"input_value": InputSocket(name="input_value", type=MyObject)}
     assert sockets == expected
 
@@ -119,7 +119,7 @@ def test_find_input_sockets_one_union_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {"input_value": InputSocket(name="input_value", type=Union[str, int])}
     assert sockets == expected
 
@@ -145,7 +145,7 @@ def test_find_input_sockets_one_optional_builtin_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {"input_value": InputSocket(name="input_value", type=Optional[int])}
     assert sockets == expected
 
@@ -174,7 +174,7 @@ def test_find_input_sockets_one_optional_object_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {"input_value": InputSocket(name="input_value", type=Optional[MyObject])}
     assert sockets == expected
 
@@ -203,7 +203,7 @@ def test_find_input_sockets_sequences_of_builtin_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "list_value": InputSocket(name="list_value", type=typing.List[int]),
         "set_value": InputSocket(name="set_value", type=typing.Set[int]),
@@ -240,7 +240,7 @@ def test_find_input_sockets_sequences_of_object_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "list_value": InputSocket(name="list_value", type=typing.List[MyObject]),
         "set_value": InputSocket(name="set_value", type=typing.Set[MyObject]),
@@ -272,7 +272,7 @@ def test_find_input_sockets_mappings_of_builtin_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "dict_value": InputSocket(name="dict_value", type=typing.Dict[str, int]),
         "mapping_value": InputSocket(name="mapping_value", type=typing.Mapping[str, int]),
@@ -305,7 +305,7 @@ def test_find_input_sockets_mappings_of_object_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "dict_value": InputSocket(name="dict_value", type=typing.Dict[str, MyObject]),
         "mapping_value": InputSocket(name="mapping_value", type=typing.Mapping[str, MyObject]),
@@ -337,7 +337,7 @@ def test_find_input_sockets_tuple_type_input():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_input_sockets(comp)
+    sockets = _find_input_sockets(comp)
     expected = {
         "tuple_value": InputSocket(name="tuple_value", type=typing.Tuple[str, MyObject]),
     }

--- a/test/pipelines/unit/test_output_sockets.py
+++ b/test/pipelines/unit/test_output_sockets.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Union, Set, Sequence, Iterable, Dict, Mapping
 
 from canals import component
 from canals.pipeline.sockets import (
-    find_output_sockets,
+    _find_output_sockets,
     OutputSocket,
 )
 
@@ -31,7 +31,7 @@ def test_find_output_sockets_one_regular_builtin_type_output():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {"output_value": OutputSocket(name="output_value", type=int)}
     assert sockets == expected
 
@@ -59,7 +59,7 @@ def test_find_output_sockets_many_regular_builtin_type_outputs():
             return self.output(int_value=1, str_value="1", bool_value=True)
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "int_value": OutputSocket(name="int_value", type=int),
         "str_value": OutputSocket(name="str_value", type=str),
@@ -92,7 +92,7 @@ def test_find_output_sockets_one_regular_object_type_output():
             return self.output(output_value=MyObject())
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {"output_value": OutputSocket(name="output_value", type=MyObject)}
     assert sockets == expected
 
@@ -118,7 +118,7 @@ def test_find_output_sockets_one_union_type_output():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {"output_value": OutputSocket(name="output_value", type=Union[str, int])}
     assert sockets == expected
 
@@ -144,7 +144,7 @@ def test_find_output_sockets_one_optional_builtin_type_output():
             return self.output(output_value=1)
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {"output_value": OutputSocket(name="output_value", type=Optional[int])}
     assert sockets == expected
 
@@ -173,7 +173,7 @@ def test_find_output_sockets_one_optional_object_type_output():
             return self.output(output_value=MyObject())
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {"output_value": OutputSocket(name="output_value", type=Optional[MyObject])}
     assert sockets == expected
 
@@ -202,7 +202,7 @@ def test_find_output_sockets_sequences_of_builtin_type_output():
             return self.output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "list_value": OutputSocket(name="list_value", type=List[int]),
         "set_value": OutputSocket(name="set_value", type=Set[int]),
@@ -239,7 +239,7 @@ def test_find_output_sockets_sequences_of_object_type_output():
             return self.output(list_value=[], set_value=set(), sequence_value=[], iterable_value=[])
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "list_value": OutputSocket(name="list_value", type=List[MyObject]),
         "set_value": OutputSocket(name="set_value", type=Set[MyObject]),
@@ -271,7 +271,7 @@ def test_find_output_sockets_mappings_of_builtin_type_output():
             return self.output(dict_value={}, mapping_value={})
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "dict_value": OutputSocket(name="dict_value", type=Dict[str, int]),
         "mapping_value": OutputSocket(name="mapping_value", type=Mapping[str, int]),
@@ -304,7 +304,7 @@ def test_find_output_sockets_mappings_of_object_type_output():
             return self.output(dict_value={}, mapping_value={})
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "dict_value": OutputSocket(name="dict_value", type=Dict[str, MyObject]),
         "mapping_value": OutputSocket(name="mapping_value", type=Mapping[str, MyObject]),
@@ -336,7 +336,7 @@ def test_find_output_sockets_tuple_type_output():
             return self.output(tuple_value=("a", MyObject()))
 
     comp = MockComponent()
-    sockets = find_output_sockets(comp)
+    sockets = _find_output_sockets(comp)
     expected = {
         "tuple_value": OutputSocket(name="tuple_value", type=Tuple[str, MyObject]),
     }

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -5,7 +5,7 @@ import pytest
 from canals.pipeline import Pipeline
 from canals.errors import PipelineValidationError
 from canals.pipeline.sockets import InputSocket, OutputSocket
-from canals.pipeline.validation import find_pipeline_inputs, find_pipeline_outputs
+from canals.pipeline.validation import _find_pipeline_inputs, _find_pipeline_outputs
 
 from test.sample_components import Double, AddFixedValue, Sum, Parity
 
@@ -17,7 +17,7 @@ def test_find_pipeline_input_no_input():
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    assert find_pipeline_inputs(pipe.graph) == {"comp1": [], "comp2": []}
+    assert _find_pipeline_inputs(pipe.graph) == {"comp1": [], "comp2": []}
 
 
 def test_find_pipeline_input_one_input():
@@ -26,7 +26,7 @@ def test_find_pipeline_input_one_input():
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
 
-    assert find_pipeline_inputs(pipe.graph) == {
+    assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [InputSocket(name="value", type=int)],
         "comp2": [],
     }
@@ -38,7 +38,7 @@ def test_find_pipeline_input_two_inputs_same_component():
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
 
-    assert find_pipeline_inputs(pipe.graph) == {
+    assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
             InputSocket(name="value", type=int),
             InputSocket(name="add", type=int),
@@ -55,7 +55,7 @@ def test_find_pipeline_input_some_inputs_different_components():
     pipe.connect("comp1", "comp3")
     pipe.connect("comp2", "comp3.add")
 
-    assert find_pipeline_inputs(pipe.graph) == {
+    assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
             InputSocket(name="value", type=int),
             InputSocket(name="add", type=int),
@@ -71,7 +71,7 @@ def test_find_pipeline_variable_input_nodes_in_the_pipeline():
     pipe.add_component("comp2", Double())
     pipe.add_component("comp3", Sum(inputs=["in_1", "in_2"]))
 
-    assert find_pipeline_inputs(pipe.graph) == {
+    assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
             InputSocket(name="value", type=int),
             InputSocket(name="add", type=int),
@@ -88,7 +88,7 @@ def test_find_pipeline_output_no_output():
     pipe.connect("comp1", "comp2")
     pipe.connect("comp2", "comp1")
 
-    assert find_pipeline_outputs(pipe.graph) == {}
+    assert _find_pipeline_outputs(pipe.graph) == {}
 
 
 def test_find_pipeline_output_one_output():
@@ -97,7 +97,7 @@ def test_find_pipeline_output_one_output():
     pipe.add_component("comp2", Double())
     pipe.connect("comp1", "comp2")
 
-    assert find_pipeline_outputs(pipe.graph) == {"comp2": [OutputSocket(name="value", type=int)]}
+    assert _find_pipeline_outputs(pipe.graph) == {"comp2": [OutputSocket(name="value", type=int)]}
 
 
 def test_find_pipeline_some_outputs_same_component():
@@ -106,7 +106,7 @@ def test_find_pipeline_some_outputs_same_component():
     pipe.add_component("comp2", Parity())
     pipe.connect("comp1", "comp2")
 
-    assert find_pipeline_outputs(pipe.graph) == {
+    assert _find_pipeline_outputs(pipe.graph) == {
         "comp2": [OutputSocket(name="even", type=int), OutputSocket(name="odd", type=int)]
     }
 
@@ -119,7 +119,7 @@ def test_find_pipeline_some_outputs_different_components():
     pipe.connect("comp1", "comp2")
     pipe.connect("comp1", "comp3")
 
-    assert find_pipeline_outputs(pipe.graph) == {
+    assert _find_pipeline_outputs(pipe.graph) == {
         "comp2": [OutputSocket(name="even", type=int), OutputSocket(name="odd", type=int)],
         "comp3": [
             OutputSocket(name="value", type=int),


### PR DESCRIPTION
`draw` module has been moved in `pipeline` module and all its methods defined as private.

The only public API to draw a pipeline will be `Pipeline.draw()` as it currently is.

This PR also makes all the validation, connections and sockets handling methods private as they must not be part of the public interface.

Depends on #53 