### PR TITLE
Include only required files in built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ Source = "https://github.com/deepset-ai/canals"
 [tool.hatch.version]
 path = "canals/__about__.py"
 
+[tool.hatch.build]
+include = ["/canals/**/*.py"]
+
 [tool.hatch.envs.default]
 dependencies = ["pytest", "pytest-cov", "requests"]
 


### PR DESCRIPTION
With this change we include only `.py` files found in the `canals` folder.
Previously we were including most files in the project excluding those in `.gitignore` has Hatch respects that by default.