### PR TITLE
Remove Component's I/O type checks at run time

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -44,9 +44,6 @@ def _prepare_init_params_and_sockets(init_func):
         # Collect and store all the init parameters, preserving whatever the components might have already added there
         self.init_parameters = {**kwargs, **getattr(self, "init_parameters", {})}
 
-        if not hasattr(self.run, "__canals_io__"):
-            raise ComponentError("This component seems to have neither inputs nor outputs.")
-
     return wrapper
 
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from canals import component
@@ -62,3 +64,57 @@ def test_missing_run():
         class MockComponent:
             def another_method(self, input_value: int):
                 return {"output_value": input_value}
+
+
+def test_set_input_types():
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=Any)
+
+        @component.output_types(value=int)
+        def run(self, **kwargs):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.run.__canals_io__["input_types"] == {
+        "value": {
+            "name": "value",
+            "type": Any,
+            "is_optional": False,
+        }
+    }
+    assert comp.run() == {"value": 1}
+
+
+def test_set_output_types():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_output_types(self, value=int)
+
+        def run(self, value: int):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.run.__canals_io__["output_types"] == {
+        "value": {
+            "name": "value",
+            "type": int,
+        }
+    }
+
+
+def test_output_types_decorator_with_compatible_type():
+    @component
+    class MockComponent:
+        @component.output_types(value=int)
+        def run(self, value: int):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.run.__canals_io__["output_types"] == {
+        "value": {
+            "name": "value",
+            "type": int,
+        }
+    }

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -1,10 +1,8 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 
 from canals.testing import BaseTestComponent
-from canals.errors import ComponentError
 from sample_components import Sum
 
 
@@ -20,8 +18,7 @@ class TestSum(BaseTestComponent):
 
     def test_sum_expects_no_values_receives_one_value(self):
         component = Sum(inputs=[])
-        with pytest.raises(ComponentError):
-            component.run(value_1=10)
+        assert component.run(value_1=10) == {"total": 10}
 
     def test_sum_expects_one_value_receives_one_value(self):
         component = Sum(inputs=["value_1"])
@@ -31,13 +28,11 @@ class TestSum(BaseTestComponent):
 
     def test_sum_expects_one_value_receives_wrong_value(self):
         component = Sum(inputs=["value_1"])
-        with pytest.raises(ComponentError):
-            component.run(something_else=10)
+        assert component.run(something_else=10) == {"total": 10}
 
     def test_sum_expects_one_value_receives_few_values(self):
         component = Sum(inputs=["value_1"])
-        with pytest.raises(ComponentError):
-            component.run(value_1=10, value_2=2)
+        assert component.run(value_1=10, value_2=2) == {"total": 12}
 
     def test_sum_expects_few_values_receives_right_values(self):
         component = Sum(inputs=["value_1", "value_2", "value_3"])
@@ -47,5 +42,4 @@ class TestSum(BaseTestComponent):
 
     def test_sum_expects_few_values_receives_some_wrong_values(self):
         component = Sum(inputs=["value_1", "value_2", "value_3"])
-        with pytest.raises(ComponentError):
-            component.run(value_1=10, value_4=11, value_3=12)
+        assert component.run(value_1=10, value_4=11, value_3=12) == {"total": 33}


### PR DESCRIPTION
Verifying I/O types at run time is not a good practice as it's extremely hard and error prone since Python is a dynamic language.

Comparing Component's output is close to impossible without limiting extremely the possible output types. Since it's good enough to have validation in Pipeline when connecting Components we decided to remove the run time checks.

