### PR TITLE
Add component `from_dict` and `to_dict` methods

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -4,10 +4,10 @@
 
 import logging
 import inspect
-from typing import Protocol, Union, Dict, Any, get_origin, get_args
+from typing import Protocol, Union, Dict, Type, Any, get_origin, get_args
 from functools import wraps
 
-from canals.errors import ComponentError
+from canals.errors import ComponentError, ComponentDeserializationError
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +28,17 @@ class Component(Protocol):  # pylint: disable=too-few-public-methods
         Inputs are defined explicitly by the run method's signature or with `component.set_input_types()` if dynamic.
         Outputs are defined by decorating the run method with `@component.output_types()`
         or with `component.set_output_types()` if dynamic.
+        """
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes the component to a dictionary.
+        """
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Component":
+        """
+        Deserializes the component from a dictionary.
         """
 
 
@@ -256,6 +267,12 @@ class _Component:
 
         setattr(class_, "__canals_component__", True)
 
+        if not hasattr(class_, "to_dict"):
+            class_.to_dict = _default_component_to_dict
+
+        if not hasattr(class_, "from_dict"):
+            class_.from_dict = classmethod(_default_component_from_dict)
+
         return class_
 
     def __call__(self, class_=None):
@@ -274,3 +291,28 @@ def _is_optional(type_: type) -> bool:
     Utility method that returns whether a type is Optional.
     """
     return get_origin(type_) is Union and type(None) in get_args(type_)
+
+
+def _default_component_to_dict(comp: Component) -> Dict[str, Any]:
+    """
+    Default component serializer.
+    Serializes a component to a dictionary.
+    """
+    return {
+        "hash": id(comp),
+        "type": comp.__class__.__name__,
+        "init_parameters": getattr(comp, "init_parameters", {}),
+    }
+
+
+def _default_component_from_dict(cls: Type[Component], data: Dict[str, Any]) -> Component:
+    """
+    Default component deserializer.
+    The "type" field in `data` must match the class that is being deserialized into.
+    """
+    init_params = data.get("init_parameters", {})
+    if "type" not in data:
+        raise ComponentDeserializationError("Missing 'type' in component serialization data")
+    if data["type"] != cls.__name__:
+        raise ComponentDeserializationError(f"Component '{data['type']}' can't be deserialized as '{cls.__name__}'")
+    return cls(**init_params)

--- a/canals/errors.py
+++ b/canals/errors.py
@@ -31,3 +31,7 @@ class PipelineUnmarshalError(PipelineError):
 
 class ComponentError(Exception):
     pass
+
+
+class ComponentDeserializationError(Exception):
+    pass

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,9 +1,12 @@
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
 from canals import component
-from canals.errors import ComponentError
+from canals.component.component import _default_component_to_dict, _default_component_from_dict
+from canals.testing import factory
+from canals.errors import ComponentError, ComponentDeserializationError
 
 
 def test_correct_declaration():
@@ -129,3 +132,36 @@ def test_component_decorator_set_it_as_component():
 
     comp = MockComponent()
     assert comp.__canals_component__
+
+
+def test_default_component_to_dict():
+    MyComponent = factory.component_class("MyComponent")
+    comp = MyComponent()
+    res = _default_component_to_dict(comp)
+    assert res == {
+        "hash": id(comp),
+        "type": "MyComponent",
+        "init_parameters": {},
+    }
+
+
+def test_default_component_from_dict():
+    MyComponent = factory.component_class("MyComponent")
+    comp = _default_component_from_dict(MyComponent, {"type": "MyComponent"})
+    assert isinstance(comp, MyComponent)
+
+
+def test_default_component_from_dict_without_type():
+    with pytest.raises(ComponentDeserializationError, match="Missing 'type' in component serialization data"):
+        _default_component_from_dict(Mock, {})
+
+
+def test_default_component_from_dict_unregistered_component(request):
+    # We use the test function name as component name to make sure it's not registered.
+    # Since the registry is global we risk to have a component with the same name registered in another test.
+    component_name = request.node.name
+
+    with pytest.raises(
+        ComponentDeserializationError, match=f"Component '{component_name}' can't be deserialized as 'Mock'"
+    ):
+        _default_component_from_dict(Mock, {"type": component_name})

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -145,10 +145,36 @@ def test_default_component_to_dict():
     }
 
 
+def test_default_component_to_dict_with_init_parameters():
+    extra_fields = {"init_parameters": {"some_key": "some_value"}}
+    MyComponent = factory.component_class("MyComponent", extra_fields=extra_fields)
+    comp = MyComponent()
+    res = _default_component_to_dict(comp)
+    assert res == {
+        "hash": id(comp),
+        "type": "MyComponent",
+        "init_parameters": {"some_key": "some_value"},
+    }
+
+
 def test_default_component_from_dict():
-    MyComponent = factory.component_class("MyComponent")
-    comp = _default_component_from_dict(MyComponent, {"type": "MyComponent"})
+    def custom_init(self, some_param):
+        self.some_param = some_param
+
+    extra_fields = {"__init__": custom_init}
+    MyComponent = factory.component_class("MyComponent", extra_fields=extra_fields)
+    comp = _default_component_from_dict(
+        MyComponent,
+        {
+            "type": "MyComponent",
+            "init_parameters": {
+                "some_param": 10,
+            },
+            "hash": 1234,
+        },
+    )
     assert isinstance(comp, MyComponent)
+    assert comp.some_param == 10
 
 
 def test_default_component_from_dict_without_type():


### PR DESCRIPTION
Add `from_dict` and `to_dict` to `Component` interface.

All classes decorated with `@components` will have a default implementation added.

Given a `MyComponent` class that accepts a `value` parameter in `__init__` `to_dict()` will create a dictionary similar to this:
```
{
        "hash": <id_of_the_instance>,
        "type": "MyComponent",
        "init_parameters": { "value": 100 },
 }
```

`MyComponent.from_dict()` will instead return a new instance of `MyComponent` given the above dictionary.

Trying to call `OtherComponent.from_dict()` using the above dictionary will fail.
