### PR TITLE
fix: handle falsy node I/O properly

### DIFF
--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -794,7 +794,7 @@ class Pipeline:
                     inputs_buffer[target_node] = {}  # Create the buffer for the downstream node if it's not there yet
 
                 value_to_route = node_results.get(from_socket.name, None)
-                if value_to_route:
+                if value_to_route is not None:
                     inputs_buffer[target_node][to_socket.name] = value_to_route
 
         return inputs_buffer

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -82,7 +82,7 @@ def _validate_nodes_receive_only_expected_input(graph: networkx.MultiDiGraph, in
     """
     for node, input_data in input_values.items():
         for socket_name in input_data.keys():
-            if not input_data.get(socket_name, None):
+            if input_data.get(socket_name, None) is None:
                 continue
             if not socket_name in graph.nodes[node]["input_sockets"].keys():
                 raise ValueError(

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -66,10 +66,11 @@ def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_va
     for node, sockets in valid_inputs.items():
         for socket in sockets:
             inputs_for_node = input_values.get(node, {})
+            print(inputs_for_node)
             missing_input_value = (
-                not inputs_for_node
+                inputs_for_node is None
                 or not socket.name in inputs_for_node.keys()
-                or not inputs_for_node.get(socket.name, None)
+                or inputs_for_node.get(socket.name, None) is None
             )
             if missing_input_value and not socket.is_optional:
                 raise ValueError(f"Missing input: {node}.{socket.name}")

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -66,7 +66,6 @@ def _validate_input_sockets_are_connected(graph: networkx.MultiDiGraph, input_va
     for node, sockets in valid_inputs.items():
         for socket in sockets:
             inputs_for_node = input_values.get(node, {})
-            print(inputs_for_node)
             missing_input_value = (
                 inputs_for_node is None
                 or not socket.name in inputs_for_node.keys()

--- a/test/pipelines/unit/test_pipeline.py
+++ b/test/pipelines/unit/test_pipeline.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 import logging
+from canals.testing.factory import component_class
 
 import pytest
 
@@ -319,16 +320,8 @@ def test_from_dict_without_connection_receiver():
     err.match("Missing receiver in connection: {'sender': 'some.sender'}")
 
 def test_falsy_connection():
-    @component
-    class A:
-        @component.output_types(y=int)
-        def run(self, x: int):
-            return {"y": 0}
-    @component
-    class B:
-        @component.output_types(y=int)
-        def run(self, x: int):
-            return {"y": x}
+    A = component_class("A", input_types={"x": int}, output={"y": 0})
+    B = component_class("A", input_types={"x": int}, output={"y": 0})
     p = Pipeline()
     p.add_component("a", A())
     p.add_component("b", B())

--- a/test/pipelines/unit/test_pipeline.py
+++ b/test/pipelines/unit/test_pipeline.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 import logging
-from canals.testing.factory import component_class
 
 import pytest
 
-from canals import Pipeline, component
+from canals import Pipeline
 from canals.pipeline.sockets import InputSocket, OutputSocket
 from canals.errors import PipelineMaxLoops, PipelineError
 from sample_components import AddFixedValue, Threshold, MergeLoop, Double
+from canals.testing.factory import component_class
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -177,6 +177,14 @@ def test_validate_pipeline_input_only_expected_input_is_present():
     with pytest.raises(ValueError, match="The input value of comp2 is already sent by node comp1"):
         pipe.run({"comp1": {"value": 1}, "comp2": {"value": 2}})
 
+def test_validate_pipeline_input_only_expected_input_is_present_falsy():
+    pipe = Pipeline()
+    pipe.add_component("comp1", Double())
+    pipe.add_component("comp2", Double())
+    pipe.connect("comp1", "comp2")
+    with pytest.raises(ValueError, match="The input value of comp2 is already sent by node comp1"):
+        pipe.run({"comp1": {"value": 1}, "comp2": {"value": 0}})
+
 
 def test_validate_pipeline_input_only_expected_input_is_present_including_unknown_names():
     pipe = Pipeline()

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -185,6 +185,12 @@ def test_validate_pipeline_input_only_expected_input_is_present_falsy():
     with pytest.raises(ValueError, match="The input value of comp2 is already sent by node comp1"):
         pipe.run({"comp1": {"value": 1}, "comp2": {"value": 0}})
 
+def test_validate_pipeline_falsy_input():
+    pipe = Pipeline()
+    pipe.add_component("comp", Double())
+    pipe.run({"comp": {"value": 0}})
+    with pytest.raises(ValueError, match="Missing input: comp.value"):
+        pipe.run({"comp": {}})
 
 def test_validate_pipeline_input_only_expected_input_is_present_including_unknown_names():
     pipe = Pipeline()

--- a/test/pipelines/unit/test_validation_pipeline_io.py
+++ b/test/pipelines/unit/test_validation_pipeline_io.py
@@ -185,10 +185,14 @@ def test_validate_pipeline_input_only_expected_input_is_present_falsy():
     with pytest.raises(ValueError, match="The input value of comp2 is already sent by node comp1"):
         pipe.run({"comp1": {"value": 1}, "comp2": {"value": 0}})
 
-def test_validate_pipeline_falsy_input():
+def test_validate_pipeline_falsy_input_present():
     pipe = Pipeline()
     pipe.add_component("comp", Double())
-    pipe.run({"comp": {"value": 0}})
+    assert pipe.run({"comp": {"value": 0}}) == {"comp": {"value": 0}}
+        
+def test_validate_pipeline_falsy_input_missing():
+    pipe = Pipeline()
+    pipe.add_component("comp", Double())
     with pytest.raises(ValueError, match="Missing input: comp.value"):
         pipe.run({"comp": {}})
 


### PR DESCRIPTION
As discovered in #67, outputting 0 is equivalent to outputting nothing which shouldn't be the case. The validation also misses when an input is set to 0.
This PR fixes this at two points in the code which fix the issue for me. However, it might also occur somewhere else which I have missed.

I have run the tests manually and they are all passing.