### PR TITLE
Implement generic `default_to_dict` and `default_from_dict`

### DIFF
--- a/canals/errors.py
+++ b/canals/errors.py
@@ -35,3 +35,7 @@ class ComponentError(Exception):
 
 class ComponentDeserializationError(Exception):
     pass
+
+
+class DeserializationError(Exception):
+    pass

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -13,8 +13,8 @@ def default_to_dict(obj: Any, **init_parameters) -> Dict[str, Any]:
 
     `init_parameters` are parameters passed to the object class `__init__`.
     They must be defined explicitly as they'll be used when creating a new
-    instance of `obj` with `from_dict`. Omitting them maybe cause deserialisation
-    to fail using `from_dict` to fail.
+    instance of `obj` with `from_dict`. Omitting them might cause deserialisation
+    errors or unexpected behaviours later, when calling `from_dict`.
 
     An example usage:
 

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Type, Dict, Any
+
+from canals.errors import DeserializationError
+
+
+def default_to_dict(obj: Any, **init_parameters) -> Dict[str, Any]:
+    """
+    Utility function to serialize an object to a dictionary.
+    This is mostly necessary for Components but it can be used by any object.
+
+    `init_parameters` are parameters passed to the object class `__init__`.
+    They must be defined explicitly as they'll be used when creating a new
+    instance of `obj` with `from_dict`. Omitting them maybe cause deserialisation
+    to fail using `from_dict` to fail.
+
+    An example usage:
+
+    ```python
+    class MyClass:
+        def __init__(self, my_param: int = 10):
+            self.my_param = my_param
+
+        def to_dict(self):
+            return default_to_dict(self, my_param=self.my_param)
+
+
+    obj = MyClass(my_param=1000)
+    data = obj.to_dict()
+    assert data == {
+        "hash": 4378522336,
+        "type": "MyClass",
+        "init_parameters": {
+            "my_param": 1000,
+        },
+    }
+    ```
+    """
+    return {
+        "hash": id(obj),
+        "type": obj.__class__.__name__,
+        "init_parameters": init_parameters,
+    }
+
+
+def default_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
+    """
+    Utility function to deserialize a dictionary to an object.
+    This is mostly necessary for Components but it can be used by any object.
+
+    The function will raise a `DeserializationError` if the `type` field in `data` is
+    missing or it doesn't match the type of `cls`.
+
+    If `data` contains an `init_parameters` field it will be used as parameters to create
+    a new instance of `cls`.
+    """
+    init_params = data.get("init_parameters", {})
+    if "type" not in data:
+        raise DeserializationError("Missing 'type' in serialization data")
+    if data["type"] != cls.__name__:
+        raise DeserializationError(f"Class '{data['type']}' can't be deserialized as '{cls.__name__}'")
+    return cls(**init_params)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock
+
+import pytest
+
+from canals.errors import DeserializationError
+from canals.testing import factory
+from canals.serialization import default_to_dict, default_from_dict
+
+
+def test_default_component_to_dict():
+    MyComponent = factory.component_class("MyComponent")
+    comp = MyComponent()
+    res = default_to_dict(comp)
+    assert res == {
+        "hash": id(comp),
+        "type": "MyComponent",
+        "init_parameters": {},
+    }
+
+
+def test_default_component_to_dict_with_init_parameters():
+    MyComponent = factory.component_class("MyComponent")
+    comp = MyComponent()
+    res = default_to_dict(comp, some_key="some_value")
+    assert res == {
+        "hash": id(comp),
+        "type": "MyComponent",
+        "init_parameters": {"some_key": "some_value"},
+    }
+
+
+def test_default_component_from_dict():
+    def custom_init(self, some_param):
+        self.some_param = some_param
+
+    extra_fields = {"__init__": custom_init}
+    MyComponent = factory.component_class("MyComponent", extra_fields=extra_fields)
+    comp = default_from_dict(
+        MyComponent,
+        {
+            "type": "MyComponent",
+            "init_parameters": {
+                "some_param": 10,
+            },
+            "hash": 1234,
+        },
+    )
+    assert isinstance(comp, MyComponent)
+    assert comp.some_param == 10
+
+
+def test_default_component_from_dict_without_type():
+    with pytest.raises(DeserializationError, match="Missing 'type' in serialization data"):
+        default_from_dict(Mock, {})
+
+
+def test_default_component_from_dict_unregistered_component(request):
+    # We use the test function name as component name to make sure it's not registered.
+    # Since the registry is global we risk to have a component with the same name registered in another test.
+    component_name = request.node.name
+
+    with pytest.raises(DeserializationError, match=f"Class '{component_name}' can't be deserialized as 'Mock'"):
+        default_from_dict(Mock, {"type": component_name})


### PR DESCRIPTION
Part of #84.

Add generic utility functions to ease serialization and deserialization of Components and other clasess.
They are extremely similar to [`_default_component_to_dict`](https://github.com/deepset-ai/canals/blob/50c1afd1404e11321d58960196fc9231ce94654e/canals/component/component.py#L288) and [`_default_component_from_dict`](https://github.com/deepset-ai/canals/blob/50c1afd1404e11321d58960196fc9231ce94654e/canals/component/component.py#L300C5-L300C33) but with no references to `Component` as they can be used for any class and object.

Example usage:

```
class MyClass:
    def __init__(self, my_param: int = 10):
        self.my_param = my_param

    def to_dict(self):
        return default_to_dict(self, my_param=self.my_param)

    @classmethod
    def from_dict(cls, data):
        return default_from_dict(cls, data)

obj = MyClass(my_param=1000)
data = obj.to_dict()
assert data == {
    "hash": 4378522336,
    "type": "MyClass",
    "init_parameters": {
        "my_param": 1000,
    },
}

data["init_parameters"]["my_param"] = 42
new_obj = MyClass.from_dict(data)
assert new_object.my_param == 42
```


This PR only adds them and their tests to keep it small. Further PRs will remove the default `to_dict` and `from_dict` added by the `@component` decorator.