### PR TITLE
Add to_dict and from_dict for Parity, Subtract, Double, Concatenate

### DIFF
--- a/sample_components/concatenate.py
+++ b/sample_components/concatenate.py
@@ -1,16 +1,24 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union, List
+from typing import Dict, Union, List, Any
 
 from canals import component
+from canals.serialization import default_to_dict, default_from_dict
 
 
 @component
-class Concatenate:  # pylint: disable=too-few-public-methods
+class Concatenate:
     """
     Concatenates two values
     """
+
+    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Concatenate":  # pylint: disable=missing-function-docstring
+        return default_from_dict(cls, data)
 
     @component.output_types(value=List[str])
     def run(self, first: Union[List[str], str], second: Union[List[str], str]):

--- a/sample_components/double.py
+++ b/sample_components/double.py
@@ -1,15 +1,24 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Dict, Any
 
+from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 
 @component
-class Double:  # pylint: disable=too-few-public-methods
+class Double:
     """
     Doubles the input value.
     """
+
+    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Double":  # pylint: disable=missing-function-docstring
+        return default_from_dict(cls, data)
 
     @component.output_types(value=int)
     def run(self, value: int):

--- a/sample_components/parity.py
+++ b/sample_components/parity.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Dict, Any
+
+from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 
@@ -9,6 +12,13 @@ class Parity:  # pylint: disable=too-few-public-methods
     """
     Redirects the value, unchanged, along the 'even' connection if even, or along the 'odd' one if odd.
     """
+
+    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Parity":  # pylint: disable=missing-function-docstring
+        return default_from_dict(cls, data)
 
     @component.output_types(even=int, odd=int)
     def run(self, value: int):

--- a/sample_components/subtract.py
+++ b/sample_components/subtract.py
@@ -1,14 +1,24 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Dict, Any
+
+from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 
 @component
-class Subtract:  # pylint: disable=too-few-public-methods
+class Subtract:
     """
     Compute the difference between two values.
     """
+
+    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
+        return default_to_dict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Subtract":  # pylint: disable=missing-function-docstring
+        return default_from_dict(cls, data)
 
     @component.output_types(difference=int)
     def run(self, first_value: int, second_value: int):

--- a/test/sample_components/test_concatenate.py
+++ b/test/sample_components/test_concatenate.py
@@ -6,8 +6,15 @@ from sample_components import Concatenate
 
 
 class TestConcatenate(BaseTestComponent):
-    def test_saveload_default(self, tmp_path):
-        self.assert_can_be_saved_and_loaded_in_pipeline(Concatenate(), tmp_path)
+    def test_to_dict(self):
+        component = Concatenate()
+        res = component.to_dict()
+        assert res == {"hash": id(component), "type": "Concatenate", "init_parameters": {}}
+
+    def test_from_dict(self):
+        data = {"hash": 12345, "type": "Concatenate", "init_parameters": {}}
+        component = Concatenate.from_dict(data)
+        assert component
 
     def test_input_lists(self):
         component = Concatenate()

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -7,8 +7,15 @@ from sample_components import Double
 
 
 class TestDouble(BaseTestComponent):
-    def test_saveload_default(self, tmp_path):
-        self.assert_can_be_saved_and_loaded_in_pipeline(Double(), tmp_path)
+    def test_to_dict(self):
+        component = Double()
+        res = component.to_dict()
+        assert res == {"hash": id(component), "type": "Double", "init_parameters": {}}
+
+    def test_from_dict(self):
+        data = {"hash": 12345, "type": "Double", "init_parameters": {}}
+        component = Double.from_dict(data)
+        assert component
 
     def test_double_default(self):
         component = Double()

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -6,8 +6,15 @@ from sample_components import Parity
 
 
 class TestParity(BaseTestComponent):
-    def test_saveload_default(self, tmp_path):
-        self.assert_can_be_saved_and_loaded_in_pipeline(Parity(), tmp_path)
+    def test_to_dict(self):
+        component = Parity()
+        res = component.to_dict()
+        assert res == {"hash": id(component), "type": "Parity", "init_parameters": {}}
+
+    def test_from_dict(self):
+        data = {"hash": 12345, "type": "Parity", "init_parameters": {}}
+        component = Parity.from_dict(data)
+        assert component
 
     def test_parity(self):
         component = Parity()

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -6,8 +6,15 @@ from sample_components import Subtract
 
 
 class TestSubtract(BaseTestComponent):
-    def test_saveload_default(self, tmp_path):
-        self.assert_can_be_saved_and_loaded_in_pipeline(Subtract(), tmp_path)
+    def test_to_dict(self):
+        component = Subtract()
+        res = component.to_dict()
+        assert res == {"hash": id(component), "type": "Subtract", "init_parameters": {}}
+
+    def test_from_dict(self):
+        data = {"hash": 12345, "type": "Subtract", "init_parameters": {}}
+        component = Subtract.from_dict(data)
+        assert component
 
     def test_subtract(self):
         component = Subtract()


### PR DESCRIPTION
Depends on #85.

Add `to_dict` and `from_dict` for those Components that didn't have it.
