### PR TITLE
Change _to_mermaid_text to use component serialization data

### DIFF
--- a/canals/pipeline/draw/mermaid.py
+++ b/canals/pipeline/draw/mermaid.py
@@ -65,13 +65,13 @@ def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
     Converts a Networkx graph into Mermaid syntax. The output of this function can be used in the documentation
     with `mermaid` codeblocks and it will be automatically rendered.
     """
-    init_params = {
-        comp: ",<br>".join(
-            [f"{key}={json.dumps(value)}" for key, value in getattr(data["instance"], "init_parameters", {}).items()]
-        )
-        for comp, data in graph.nodes(data=True)
-        if comp not in ["input", "output"]
-    }
+    init_params = {}
+    for name, comp in graph.nodes(data="instance"):
+        if name in ["input", "output"]:
+            continue
+        data = comp.to_dict()
+        params = [f"{k}={json.dumps(v)}" for k, v in data.get("init_parameters", {}).items()]
+        init_params[name] = ",<br>".join(params)
     states = "\n".join(
         [
             f"{comp}:::components: <b>{comp}</b><br><small><i>{type(data['instance']).__name__}({init_params[comp]})</i></small>"


### PR DESCRIPTION
`_to_mermaid_text` relies on a `Component` instance having an `init_parameters` field to correctly generate the Mermaid text to draw a `Pipeline`.

Since we remove the setting of `init_parameters` from `@component` that's not going to be reliable anymore. We can instead rely on `Component.to_dict()` to get a representation of the `init_parameters`.

I found out about this issue from PR #88 checks failing.
https://github.com/deepset-ai/canals/actions/runs/5901611206/job/16008083697?pr=88