### PR TITLE
Revert "Check Component I/O socket names are valid (#100)"

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -71,7 +71,6 @@
 import logging
 import inspect
 from typing import Protocol, Union, Dict, Any, get_origin, get_args
-from keyword import iskeyword
 from functools import wraps
 
 from canals.errors import ComponentError
@@ -129,7 +128,6 @@ class _Component:
     def set_input_types(self, instance, **types):
         """
         Method that validates the input kwargs of the run method.
-        `types` names must be valid Python identifiers and must not clash with any keyword.
 
         Use as:
 
@@ -146,12 +144,6 @@ class _Component:
                 return {"output_1": kwargs["value_1"], "output_2": ""}
         ```
         """
-        for name in types:
-            if not _is_valid_socket_name(name):
-                raise ComponentError(
-                    f"Invalid socket name '{name}'. Socket names must be valid Python identifiers and must not clash with any keyword."
-                )
-
         run_method = instance.run
 
         def wrapper(**kwargs):
@@ -169,7 +161,6 @@ class _Component:
     def set_output_types(self, instance, **types):
         """
         Method that validates the output dictionary of the run method.
-        `types` names must be valid Python identifiers and must not clash with any keyword.
 
         Use as:
 
@@ -188,12 +179,6 @@ class _Component:
         if not types:
             return
 
-        for name in types:
-            if not _is_valid_socket_name(name):
-                raise ComponentError(
-                    f"Invalid socket name '{name}'. Socket names must be valid Python identifiers and must not clash with any keyword."
-                )
-
         run_method = instance.run
 
         def wrapper(*args, **kwargs):
@@ -209,7 +194,6 @@ class _Component:
     def output_types(self, **types):
         """
         Decorator factory that validates the output dictionary of the run method.
-        `types` names must be valid Python identifiers and must not clash with any keyword.
 
         Use as:
 
@@ -221,11 +205,6 @@ class _Component:
                 return {"output_1": 1, "output_2": "2"}
         ```
         """
-        for name in types:
-            if not _is_valid_socket_name(name):
-                raise ComponentError(
-                    f"Invalid socket name '{name}'. Socket names must be valid Python identifiers and must not clash with any keyword."
-                )
 
         def output_types_decorator(run_method):
             """
@@ -306,11 +285,3 @@ def _is_optional(type_: type) -> bool:
     Utility method that returns whether a type is Optional.
     """
     return get_origin(type_) is Union and type(None) in get_args(type_)
-
-
-def _is_valid_socket_name(name: str) -> bool:
-    """
-    Utility method that checks if a string a valid socket name.
-    Socket names must be valid Python identifiers and must clash with any keyword.
-    """
-    return name.isidentifier() and not iskeyword(name)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 
 from canals import component
-from canals.component.component import _is_valid_socket_name
 from canals.errors import ComponentError
 
 
@@ -115,28 +114,6 @@ def test_set_input_types():
     assert comp.run() == {"value": 1}
 
 
-def test_set_input_types_with_invalid_socket_name():
-    class MockComponent:
-        def __init__(self):
-            component.set_input_types(self, **{"non valid": Any})
-
-        def to_dict(self):
-            return {}
-
-        @classmethod
-        def from_dict(cls, data):
-            return cls()
-
-        @component.output_types(value=int)
-        def run(self, **kwargs):
-            return {"value": 1}
-
-    with pytest.raises(ComponentError) as err:
-        MockComponent()
-
-    err.match("Invalid socket name 'non valid'")
-
-
 def test_set_output_types():
     @component
     class MockComponent:
@@ -162,27 +139,6 @@ def test_set_output_types():
     }
 
 
-def test_set_output_types_with_invalid_socket_name():
-    class MockComponent:
-        def __init__(self):
-            component.set_output_types(self, **{"non valid": Any})
-
-        def to_dict(self):
-            return {}
-
-        @classmethod
-        def from_dict(cls, data):
-            return cls()
-
-        def run(self, value: int):
-            return {"non valid": 1}
-
-    with pytest.raises(ComponentError) as err:
-        MockComponent()
-
-    err.match("Invalid socket name 'non valid'")
-
-
 def test_output_types_decorator_with_compatible_type():
     @component
     class MockComponent:
@@ -206,25 +162,6 @@ def test_output_types_decorator_with_compatible_type():
     }
 
 
-def test_output_types_decorator_with_invalid_socket_name():
-    with pytest.raises(ComponentError) as err:
-
-        @component
-        class MockComponent:
-            @component.output_types(**{"non valid": int})
-            def run(self, value: int):
-                return {"non valid": 1}
-
-            def to_dict(self):
-                return {}
-
-            @classmethod
-            def from_dict(cls, data):
-                return cls()
-
-    err.match("Invalid socket name 'non valid'")
-
-
 def test_component_decorator_set_it_as_component():
     @component
     class MockComponent:
@@ -241,19 +178,3 @@ def test_component_decorator_set_it_as_component():
 
     comp = MockComponent()
     assert comp.__canals_component__
-
-
-def test_is_valid_socket_name():
-    assert _is_valid_socket_name("socket_name")
-    assert _is_valid_socket_name("with_underscore")
-    assert _is_valid_socket_name("value1")
-
-    assert not _is_valid_socket_name("1")
-    assert not _is_valid_socket_name(" ")
-    assert not _is_valid_socket_name(" name")
-    assert not _is_valid_socket_name("if")
-    assert not _is_valid_socket_name("with space")
-    assert not _is_valid_socket_name("with-hyphen")
-    assert not _is_valid_socket_name("with.dot")
-    assert not _is_valid_socket_name("1value")
-    assert not _is_valid_socket_name("*value")


### PR DESCRIPTION
This reverts commit 4529874b562d12331ee2f4fde926ef5b5e3d24d7.

This is probably not as necessary as we thought so we're reverting.

This was thought necessary to better handle serialization of multiple `Pipeline`s but since we removed that it's not necessary anymore.

Also we already have `FileExtensionClassifier` on Haystack that can have output sockets with `/` and `-` since they're named after mime types. e.g. `["text/plain", "audio/x-wav", "image/jpeg"]`
