### PR TITLE
feat: check returned dictionary

### DIFF
--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -729,9 +729,11 @@ class Pipeline:
             # Unwrap the output
             logger.debug("   '%s' outputs: %s\n", name, outputs)
 
+            # Make sure the component returned a dictionary
             if not isinstance(outputs, dict):
                 raise PipelineRuntimeError(
-                    "Component '' did not return a dictionary. "
+                    f"Component '{name}' returned a value of type "
+                    f"'{getattr(type(outputs), '__name__', str(type(outputs)))}' instead of a dict. "
                     "Components must always return dictionaries: check the the documentation."
                 )
 

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -729,6 +729,12 @@ class Pipeline:
             # Unwrap the output
             logger.debug("   '%s' outputs: %s\n", name, outputs)
 
+            if not isinstance(outputs, dict):
+                raise PipelineRuntimeError(
+                    "Component '' did not return a dictionary. "
+                    "Components must always return dictionaries: check the the documentation."
+                )
+
         except Exception as e:
             raise PipelineRuntimeError(
                 f"{name} raised '{e.__class__.__name__}: {e}' \nInputs: {inputs}\n\n"

--- a/test/pipelines/unit/test_pipeline.py
+++ b/test/pipelines/unit/test_pipeline.py
@@ -28,17 +28,7 @@ def test_max_loops():
 
 
 def test_run_with_component_that_does_not_return_dict():
-    @component
-    class BrokenComponent:
-        def run(self, a: int):
-            return 1
-
-        def to_dict(self):
-            return {}
-
-        @classmethod
-        def from_dict(cls, data):
-            return cls()
+    BrokenComponent = component_class("BrokenComponent", input_types={"a": int}, output_types={"b": int}, output=1)
 
     pipe = Pipeline(max_loops_allowed=10)
     pipe.add_component("comp", BrokenComponent())

--- a/test/pipelines/unit/test_pipeline.py
+++ b/test/pipelines/unit/test_pipeline.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 
-from canals import Pipeline, component
+from canals import Pipeline
 from canals.pipeline.sockets import InputSocket, OutputSocket
 from canals.errors import PipelineMaxLoops, PipelineError, PipelineRuntimeError
 from sample_components import AddFixedValue, Threshold, MergeLoop, Double


### PR DESCRIPTION
Makes sure that the component's output is a dictionary and raises a meaningful error if it isn't.