### PR TITLE
Make to/from_dict optional

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -94,17 +94,6 @@ class Component(Protocol):
         or with `component.set_output_types()` if dynamic.
         """
 
-    def to_dict(self) -> Dict[str, Any]:
-        """
-        Serializes the component to a dictionary.
-        """
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Component":
-        """
-        Deserializes the component from a dictionary.
-        """
-
 
 class _Component:
     """
@@ -233,16 +222,6 @@ class _Component:
         if not hasattr(class_, "run"):
             raise ComponentError(f"{class_.__name__} must have a 'run()' method. See the docs for more information.")
         run_signature = inspect.signature(class_.run)
-
-        if not hasattr(class_, "to_dict"):
-            raise ComponentError(
-                f"{class_.__name__} must have a 'to_dict()' method. See the docs for more information."
-            )
-
-        if not hasattr(class_, "from_dict"):
-            raise ComponentError(
-                f"{class_.__name__} must have a 'from_dict()' method. See the docs for more information."
-            )
 
         # Create the input sockets
         class_.run.__canals_input__ = {

--- a/canals/errors.py
+++ b/canals/errors.py
@@ -39,3 +39,7 @@ class ComponentDeserializationError(Exception):
 
 class DeserializationError(Exception):
     pass
+
+
+class SerializationError(Exception):
+    pass

--- a/canals/pipeline/draw/mermaid.py
+++ b/canals/pipeline/draw/mermaid.py
@@ -10,6 +10,7 @@ import networkx
 
 from canals.errors import PipelineDrawingError
 from canals.utils import _type_name
+from canals.serialization import component_to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ def _to_mermaid_text(graph: networkx.MultiDiGraph) -> str:
     for name, comp in graph.nodes(data="instance"):
         if name in ["input", "output"]:
             continue
-        data = comp.to_dict()
+        data = component_to_dict(comp)
         params = [f"{k}={json.dumps(v)}" for k, v in data.get("init_parameters", {}).items()]
         init_params[name] = ",<br>".join(params)
     states = "\n".join(

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -87,11 +87,7 @@ class Pipeline:
         """
         components = {}
         for name, instance in self.graph.nodes(data="instance"):
-            if hasattr(instance, "to_dict"):
-                instance_dict = instance.to_dict()
-            else:
-                instance_dict = component_to_dict(instance)
-            components[name] = instance_dict
+            components[name] = component_to_dict(instance)
 
         connections = []
         for sender, receiver, sockets in self.graph.edges:
@@ -161,10 +157,7 @@ class Pipeline:
                     raise PipelineError(f"Component '{component_data['type']}' not imported.")
                 # Create a new one
                 component_class = component.registry[component_data["type"]]
-                if hasattr(component_class, "from_dict"):
-                    instance = component_class.from_dict(component_data)
-                else:
-                    instance = component_from_dict(component_class, component_data)
+                instance = component_from_dict(component_class, component_data)
             pipe.add_component(name=name, instance=instance)
 
         for connection in data.get("connections", []):

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -26,6 +26,7 @@ from canals.pipeline.sockets import InputSocket, OutputSocket
 from canals.pipeline.validation import _validate_pipeline_input
 from canals.pipeline.connections import _parse_connection_name, _find_unambiguous_connection
 from canals.utils import _type_name
+from canals.serialization import component_to_dict, component_from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +85,14 @@ class Pipeline:
         Returns this Pipeline instance as a dictionary.
         This is meant to be an intermediate representation but it can be also used to save a pipeline to file.
         """
-        components = {name: instance.to_dict() for name, instance in self.graph.nodes(data="instance")}
+        components = {}
+        for name, instance in self.graph.nodes(data="instance"):
+            if hasattr(instance, "to_dict"):
+                instance_dict = instance.to_dict()
+            else:
+                instance_dict = component_to_dict(instance)
+            components[name] = instance_dict
+
         connections = []
         for sender, receiver, sockets in self.graph.edges:
             (sender_socket, receiver_socket) = sockets.split("/")
@@ -152,7 +160,11 @@ class Pipeline:
                 if component_data["type"] not in component.registry:
                     raise PipelineError(f"Component '{component_data['type']}' not imported.")
                 # Create a new one
-                instance = component.registry[component_data["type"]].from_dict(component_data)
+                component_class = component.registry[component_data["type"]]
+                if hasattr(component_class, "from_dict"):
+                    instance = component_class.from_dict(component_data)
+                else:
+                    instance = component_from_dict(component_class, component_data)
             pipe.add_component(name=name, instance=instance)
 
         for connection in data.get("connections", []):

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -21,16 +21,16 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
             # This only works if the Component constructor assigns the init
             # parameter to an instance variable or property with the same name
             param_value = getattr(obj, name)
-        except AttributeError:
-            # In case the init parameter was not assigned, we use the default value
-            param_value = param.default
+        except AttributeError as e:
             # If the parameter doesn't have a default value, raise an error
-            if param_value == inspect._empty:
+            if param.empty:
                 raise SerializationError(
                     f"Cannot determined the value of the init parameter '{name}'. "
                     f"You can fix this error by assigning 'self.{name} = {name}' or adding a "
                     f"custom serialization method 'to_dict' to the class {obj.__class__.__name__}"
-                )
+                ) from e
+            # In case the init parameter was not assigned, we use the default value
+            param_value = param.default
         init_parameters[name] = param_value
 
     return default_to_dict(obj, **init_parameters)

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -23,7 +23,7 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
             param_value = getattr(obj, name)
         except AttributeError as e:
             # If the parameter doesn't have a default value, raise an error
-            if param.empty:
+            if param.default is param.empty:
                 raise SerializationError(
                     f"Cannot determined the value of the init parameter '{name}'. "
                     f"You can fix this error by assigning 'self.{name} = {name}' or adding a "

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -6,6 +6,15 @@ from typing import Type, Dict, Any
 from canals.errors import DeserializationError
 
 
+def component_to_dict(obj: Any) -> Dict[str, Any]:
+    obj_attrs = [attr for attr in dir(obj) if not attr.startswith("_")]
+    return default_to_dict(obj, **obj_attrs)
+
+
+def component_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
+    return default_from_dict(cls, data)
+
+
 def default_to_dict(obj: Any, **init_parameters) -> Dict[str, Any]:
     """
     Utility function to serialize an object to a dictionary.

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -7,6 +7,10 @@ from canals.errors import DeserializationError
 
 
 def component_to_dict(obj: Any) -> Dict[str, Any]:
+    """
+    The marshaller used by the Pipeline. If a `to_dict` method is present in the
+    component instance, that will be used instead of the default method.
+    """
     if hasattr(obj, "to_dict"):
         return obj.to_dict()
 
@@ -14,6 +18,10 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
 
 
 def component_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
+    """
+    The unmarshaller used by the Pipeline. If a `from_dict` method is present in the
+    component instance, that will be used instead of the default method.
+    """
     if hasattr(cls, "from_dict"):
         return cls.from_dict(data)
     return default_from_dict(cls, data)

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -7,11 +7,15 @@ from canals.errors import DeserializationError
 
 
 def component_to_dict(obj: Any) -> Dict[str, Any]:
-    obj_attrs = [attr for attr in dir(obj) if not attr.startswith("_")]
-    return default_to_dict(obj, **obj_attrs)
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict()
+
+    return default_to_dict(obj, **vars(obj))
 
 
 def component_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
+    if hasattr(cls, "from_dict"):
+        return cls.from_dict(data)
     return default_from_dict(cls, data)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,5 @@ disable = [
   "line-too-long",
   "missing-class-docstring",
   "missing-module-docstring",
+  "too-few-public-methods",
 ]

--- a/sample_components/greet.py
+++ b/sample_components/greet.py
@@ -18,7 +18,6 @@ class Greet:
 
     def __init__(
         self,
-        foo: str,
         message: str = "\nGreeting component says: Hi! The value is {value}\n",
         log_level: str = "INFO",
     ):

--- a/sample_components/greet.py
+++ b/sample_components/greet.py
@@ -31,13 +31,6 @@ class Greet:
         self.message = message
         self.log_level = log_level
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, message=self.message, log_level=self.log_level)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Greet":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(value=int)
     def run(self, value: int, message: Optional[str] = None, log_level: Optional[str] = None):
         """

--- a/sample_components/greet.py
+++ b/sample_components/greet.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Dict, Any
+from typing import Optional
 import logging
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 logger = logging.getLogger(__name__)

--- a/sample_components/greet.py
+++ b/sample_components/greet.py
@@ -18,6 +18,7 @@ class Greet:
 
     def __init__(
         self,
+        foo: str,
         message: str = "\nGreeting component says: Hi! The value is {value}\n",
         log_level: str = "INFO",
     ):

--- a/test/sample_components/test_greet.py
+++ b/test/sample_components/test_greet.py
@@ -4,11 +4,12 @@
 import logging
 
 from sample_components import Greet
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Greet()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {
         "type": "Greet",
         "init_parameters": {
@@ -20,7 +21,7 @@ def test_to_dict():
 
 def test_to_dict_with_custom_parameters():
     component = Greet(message="My message", log_level="ERROR")
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {
         "type": "Greet",
         "init_parameters": {
@@ -35,7 +36,7 @@ def test_from_dict():
         "type": "Greet",
         "init_parameters": {},
     }
-    component = Greet.from_dict(data)
+    component = component_from_dict(Greet, data)
     assert component.message == "\nGreeting component says: Hi! The value is {value}\n"
     assert component.log_level == "INFO"
 
@@ -45,7 +46,7 @@ def test_from_with_custom_parameters():
         "type": "Greet",
         "init_parameters": {"message": "My message", "log_level": "ERROR"},
     }
-    component = Greet.from_dict(data)
+    component = component_from_dict(Greet, data)
     assert component.message == "My message"
     assert component.log_level == "ERROR"
 


### PR DESCRIPTION
Writing small custom components is very common in teaching material (tutorials, presentations) and might become even more popular depending how the users will receive the new Pipelines in 2.x. Problem is, having to write a `to_dict` and `from_dict` every time is cumbersome, even if the implementation is a single line thanks to the default methods provided by canals.

The idea is to remove `to_dict` and `from_dict` from the Component protocol and make them optional. We use the default serialization methods we already have when `to_dict` or `from_dict` are not present in a component class.

Caveat: when `to_dict` is not present, we inspect the `__init__` signature and see if the init parameters were assigned to an instance variable. If that wasn't the case, we resort to the default value of the parameter. If it doesn't have a default value, we raise an error.

ATM all the components have the serialization methods, so I changed `Greet` as an example of how this would look like.