### PR TITLE
fix default serialization and adjust sample components accordingly

### DIFF
--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -17,6 +17,9 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
 
     init_parameters = {}
     for name, param in inspect.signature(obj.__init__).parameters.items():
+        # Ignore `args` and `kwargs`, used by the default constructor
+        if name in ("args", "kwargs"):
+            continue
         try:
             # This only works if the Component constructor assigns the init
             # parameter to an instance variable or property with the same name
@@ -25,9 +28,9 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
             # If the parameter doesn't have a default value, raise an error
             if param.default is param.empty:
                 raise SerializationError(
-                    f"Cannot determined the value of the init parameter '{name}'. "
+                    f"Cannot determined the value of the init parameter '{name}' for the class {obj.__class__.__name__}."
                     f"You can fix this error by assigning 'self.{name} = {name}' or adding a "
-                    f"custom serialization method 'to_dict' to the class {obj.__class__.__name__}"
+                    f"custom serialization method 'to_dict' to the class."
                 ) from e
             # In case the init parameter was not assigned, we use the default value
             param_value = param.default

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -28,7 +28,7 @@ def component_to_dict(obj: Any) -> Dict[str, Any]:
             # If the parameter doesn't have a default value, raise an error
             if param.default is param.empty:
                 raise SerializationError(
-                    f"Cannot determined the value of the init parameter '{name}' for the class {obj.__class__.__name__}."
+                    f"Cannot determine the value of the init parameter '{name}' for the class {obj.__class__.__name__}."
                     f"You can fix this error by assigning 'self.{name} = {name}' or adding a "
                     f"custom serialization method 'to_dict' to the class."
                 ) from e

--- a/sample_components/add_value.py
+++ b/sample_components/add_value.py
@@ -16,13 +16,6 @@ class AddFixedValue:
     def __init__(self, add: int = 1):
         self.add = add
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, add=self.add)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "AddFixedValue":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(result=int)
     def run(self, value: int, add: Optional[int] = None):
         """

--- a/sample_components/add_value.py
+++ b/sample_components/add_value.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Dict, Any
+from typing import Optional
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/sample_components/concatenate.py
+++ b/sample_components/concatenate.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Union, List, Any
+from typing import Union, List
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/sample_components/concatenate.py
+++ b/sample_components/concatenate.py
@@ -13,13 +13,6 @@ class Concatenate:
     Concatenates two values
     """
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Concatenate":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(value=List[str])
     def run(self, first: Union[List[str], str], second: Union[List[str], str]):
         """

--- a/sample_components/double.py
+++ b/sample_components/double.py
@@ -13,13 +13,6 @@ class Double:
     Doubles the input value.
     """
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Double":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(value=int)
     def run(self, value: int):
         """

--- a/sample_components/double.py
+++ b/sample_components/double.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Any
-
-from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 

--- a/sample_components/parity.py
+++ b/sample_components/parity.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Any
-
-from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 

--- a/sample_components/parity.py
+++ b/sample_components/parity.py
@@ -13,13 +13,6 @@ class Parity:  # pylint: disable=too-few-public-methods
     Redirects the value, unchanged, along the 'even' connection if even, or along the 'odd' one if odd.
     """
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Parity":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(even=int, odd=int)
     def run(self, value: int):
         """

--- a/sample_components/remainder.py
+++ b/sample_components/remainder.py
@@ -15,13 +15,6 @@ class Remainder:
         self.divisor = divisor
         component.set_output_types(self, **{f"remainder_is_{val}": int for val in range(divisor)})
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, divisor=self.divisor)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Remainder":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     def run(self, value: int):
         """
         :param value: the value to check the remainder of.

--- a/sample_components/remainder.py
+++ b/sample_components/remainder.py
@@ -1,10 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Any
-
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/sample_components/repeat.py
+++ b/sample_components/repeat.py
@@ -13,13 +13,6 @@ class Repeat:
         self.outputs = outputs
         component.set_output_types(self, **{k: int for k in outputs})
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, outputs=self.outputs)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Repeat":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     def run(self, value: int):
         """
         :param value: the value to repeat.

--- a/sample_components/repeat.py
+++ b/sample_components/repeat.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import List, Dict, Any
+from typing import List
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/sample_components/subtract.py
+++ b/sample_components/subtract.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Dict, Any
-
-from canals.serialization import default_to_dict, default_from_dict
 from canals import component
 
 

--- a/sample_components/subtract.py
+++ b/sample_components/subtract.py
@@ -13,13 +13,6 @@ class Subtract:
     Compute the difference between two values.
     """
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Subtract":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(difference=int)
     def run(self, first_value: int, second_value: int):
         """

--- a/sample_components/sum.py
+++ b/sample_components/sum.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, List, Dict, Any
+from typing import Optional, List
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/sample_components/sum.py
+++ b/sample_components/sum.py
@@ -13,13 +13,6 @@ class Sum:
         self.inputs = inputs
         component.set_input_types(self, **{input_name: Optional[int] for input_name in inputs})
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, inputs=self.inputs)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Sum":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(total=int)
     def run(self, **kwargs):
         """

--- a/sample_components/threshold.py
+++ b/sample_components/threshold.py
@@ -22,13 +22,6 @@ class Threshold:  # pylint: disable=too-few-public-methods
         """
         self.threshold = threshold
 
-    def to_dict(self) -> Dict[str, Any]:  # pylint: disable=missing-function-docstring
-        return default_to_dict(self, threshold=self.threshold)
-
-    @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Threshold":  # pylint: disable=missing-function-docstring
-        return default_from_dict(cls, data)
-
     @component.output_types(above=int, below=int)
     def run(self, value: int, threshold: Optional[int] = None):
         """

--- a/sample_components/threshold.py
+++ b/sample_components/threshold.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Dict, Any
+from typing import Optional
 
 from canals import component
-from canals.serialization import default_to_dict, default_from_dict
 
 
 @component

--- a/test/sample_components/test_add_value.py
+++ b/test/sample_components/test_add_value.py
@@ -2,29 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import AddFixedValue
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = AddFixedValue()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "AddFixedValue", "init_parameters": {"add": 1}}
 
 
 def test_to_dict_with_custom_add_value():
     component = AddFixedValue(add=100)
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "AddFixedValue", "init_parameters": {"add": 100}}
 
 
 def test_from_dict():
     data = {"type": "AddFixedValue"}
-    component = AddFixedValue.from_dict(data)
+    component = component_from_dict(AddFixedValue, data)
     assert component.add == 1
 
 
 def test_from_dict_with_custom_add_value():
     data = {"type": "AddFixedValue", "init_parameters": {"add": 100}}
-    component = AddFixedValue.from_dict(data)
+    component = component_from_dict(AddFixedValue, data)
     assert component.add == 100
 
 

--- a/test/sample_components/test_concatenate.py
+++ b/test/sample_components/test_concatenate.py
@@ -2,17 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import Concatenate
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Concatenate()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Concatenate", "init_parameters": {}}
 
 
 def test_from_dict():
     data = {"type": "Concatenate", "init_parameters": {}}
-    component = Concatenate.from_dict(data)
+    component = component_from_dict(Concatenate, data)
     assert component
 
 

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -3,17 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from sample_components import Double
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Double()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Double", "init_parameters": {}}
 
 
 def test_from_dict():
     data = {"type": "Double", "init_parameters": {}}
-    component = Double.from_dict(data)
+    component = component_from_dict(Double, data)
     assert component
 
 

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -2,17 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import Parity
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Parity()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Parity", "init_parameters": {}}
 
 
 def test_from_dict():
     data = {"type": "Parity", "init_parameters": {}}
-    component = Parity.from_dict(data)
+    component = component_from_dict(Parity, data)
     assert component
 
 

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -4,29 +4,30 @@
 import pytest
 
 from sample_components import Remainder
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Remainder()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Remainder", "init_parameters": {"divisor": 3}}
 
 
 def test_to_dict_with_custom_divisor_value():
     component = Remainder(divisor=100)
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Remainder", "init_parameters": {"divisor": 100}}
 
 
 def test_from_dict():
     data = {"type": "Remainder"}
-    component = Remainder.from_dict(data)
+    component = component_from_dict(Remainder, data)
     assert component.divisor == 3
 
 
 def test_from_dict_with_custom_divisor_value():
     data = {"type": "Remainder", "init_parameters": {"divisor": 100}}
-    component = Remainder.from_dict(data)
+    component = component_from_dict(Remainder, data)
     assert component.divisor == 100
 
 

--- a/test/sample_components/test_repeat.py
+++ b/test/sample_components/test_repeat.py
@@ -2,17 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import Repeat
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Repeat(outputs=["first", "second"])
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Repeat", "init_parameters": {"outputs": ["first", "second"]}}
 
 
 def test_from_dict():
     data = {"type": "Repeat", "init_parameters": {"outputs": ["first", "second"]}}
-    component = Repeat.from_dict(data)
+    component = component_from_dict(Repeat, data)
     assert component.outputs == ["first", "second"]
 
 

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -2,17 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import Subtract
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Subtract()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Subtract", "init_parameters": {}}
 
 
 def test_from_dict():
     data = {"type": "Subtract", "init_parameters": {}}
-    component = Subtract.from_dict(data)
+    component = component_from_dict(Subtract, data)
     assert component
 
 

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -3,17 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from sample_components import Sum
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Sum(inputs=["first", "second"])
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Sum", "init_parameters": {"inputs": ["first", "second"]}}
 
 
 def test_from_dict():
     data = {"type": "Sum", "init_parameters": {"inputs": ["first", "second"]}}
-    component = Sum.from_dict(data)
+    component = component_from_dict(Sum, data)
     assert component.inputs == ["first", "second"]
 
 

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -2,29 +2,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from sample_components import Threshold
+from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
     component = Threshold()
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Threshold", "init_parameters": {"threshold": 10}}
 
 
 def test_to_dict_with_custom_threshold_value():
     component = Threshold(threshold=100)
-    res = component.to_dict()
+    res = component_to_dict(component)
     assert res == {"type": "Threshold", "init_parameters": {"threshold": 100}}
 
 
 def test_from_dict():
     data = {"type": "Threshold"}
-    component = Threshold.from_dict(data)
+    component = component_from_dict(Threshold, data)
     assert component.threshold == 10
 
 
 def test_from_dict_with_custom_threshold_value():
     data = {"type": "Threshold", "init_parameters": {"threshold": 100}}
-    component = Threshold.from_dict(data)
+    component = component_from_dict(Threshold, data)
     assert component.threshold == 100
 
 


### PR DESCRIPTION
I introduced a bug in #107: when you don't provide an `__init__` method, Python provides a default constructor with the signature `__init__(self, *args, **kwargs)`. This caused `inspect` to return `dict_items([('args', <Parameter "*args">), ('kwargs', <Parameter "**kwargs">)])` causing canals to complain with `canals.errors.SerializationError: Cannot determined the value of the init parameter 'args'...`.

The fix just ignores `args` and `kwargs` during the inspection. This would break if an user has a custom components with something like `def __init__(self, args: str = "my args")` but I'd argue such a user deserves a long debugging session as a punishment.

In this same PR (let me know if you want it separated):
- Remove trivial serialization methods from sample components
- Adjusted the tests accordingly
- Slightly changed the error message to make the class name more prominent (this is to make debugging a bit easier for the aforementioned evil user)