### PR TITLE
proposal: let sockets take more than one input

### DIFF
--- a/canals/pipeline/sockets.py
+++ b/canals/pipeline/sockets.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+from typing import Optional, List
 import logging
 from dataclasses import dataclass
 
@@ -14,7 +14,7 @@ class InputSocket:
     name: str
     type: type
     is_optional: bool
-    sender: Optional[str] = None
+    sender: Optional[List[str]] = None
 
 
 @dataclass

--- a/canals/pipeline/validation.py
+++ b/canals/pipeline/validation.py
@@ -91,5 +91,5 @@ def _validate_nodes_receive_only_expected_input(graph: networkx.MultiDiGraph, in
                 )
 
             sender = graph.nodes[node]["input_sockets"][socket_name].sender
-            if sender:
+            if sender is not None:
                 raise ValueError(f"The input {socket_name} of {node} is already sent by node {sender}")

--- a/test/pipelines/integration/test_fan_in.py
+++ b/test/pipelines/integration/test_fan_in.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from pathlib import Path
+from pprint import pprint
+
+from canals.pipeline import Pipeline
+from sample_components import AddFixedValue, Double
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def test_pipeline(tmp_path):
+    pipeline = Pipeline()
+    pipeline.add_component("inc", AddFixedValue(add=1))
+    pipeline.add_component("dec", AddFixedValue(add=-1))
+    pipeline.add_component("double", Double())
+
+    pipeline.connect("inc", "double")
+    pipeline.connect("dec", "double")
+
+    pipeline.draw(tmp_path / "linear_pipeline.png")
+
+    results = pipeline.run({"inc": {"value": 4}, "dec": {"value": 11}})
+    pprint(results)
+
+    assert results == {"double": {"value": 30}}
+
+
+if __name__ == "__main__":
+    test_pipeline(Path(__file__).parent)


### PR DESCRIPTION
## Problem

Currently input slots in components only accept one connection, making impossible to implement a pipeline like the one contained in `test_fan_in.py`:

![image](https://github.com/deepset-ai/canals/assets/7241/a82ebe77-5db0-4074-af4d-0a12a06fafbb)

## Possible solution

Inspired by https://github.com/deepset-ai/haystack/pull/5852/files#diff-61e3257ab10d360ea92ec14fe39f6476166a86153f9f047dfbc5316f725e636bR47 this PR contains a POC to overcome this limitation:

- Instead of limiting the input socket to one single value, we keep a list of upstream components that have been connected
- When running the pipeline, we use the `+` operator to get a single value out of the list of values produced by the upstream components that were previously connected.

## Open questions

I have some questions that I'd like to discuss in this draft:
1. What do we do with input types that don't support `+`?
2. Is `_route_output` the right place where to merge input values?
3. Do we want to provide a custom way to merge values instead of hardcoding `+`? If yes, is the current solution future proof in this sense?