### PR TITLE
fix: Sockets named "text/plain" or containing a "/" fail during pipeline.to_dict

### DIFF
--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -307,7 +307,7 @@ class Pipeline:
 
         # Create the connection
         logger.debug("Connecting '%s.%s' to '%s.%s'", from_node, from_socket.name, to_node, to_socket.name)
-        edge_key = str(hash(f"{from_socket.name}/{to_socket.name}"))
+        edge_key = f"{from_socket.name}/{to_socket.name}"
         self.graph.add_edge(
             from_node,
             to_node,

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -89,8 +89,9 @@ class Pipeline:
             components[name] = component_to_dict(instance)
 
         connections = []
-        for sender, receiver, sockets in self.graph.edges:
-            (sender_socket, receiver_socket) = sockets.split("/")
+        for sender, receiver, edge_data in self.graph.edges.data():
+            sender_socket = edge_data["from_socket"].name
+            receiver_socket = edge_data["to_socket"].name
             connections.append(
                 {
                     "sender": f"{sender}.{sender_socket}",
@@ -306,7 +307,7 @@ class Pipeline:
 
         # Create the connection
         logger.debug("Connecting '%s.%s' to '%s.%s'", from_node, from_socket.name, to_node, to_socket.name)
-        edge_key = f"{from_socket.name}/{to_socket.name}"
+        edge_key = str(hash(f"{from_socket.name}/{to_socket.name}"))
         self.graph.add_edge(
             from_node,
             to_node,


### PR DESCRIPTION
### Related Issues:
- fixes #130 

### Proposed Changes:
- Getting sender and receiver edge names separately from graph_edges rather than splitting by "/"

### How did you test it?
Manual tests with end-to-end test in Haystack https://github.com/deepset-ai/haystack/pull/6037

### Notes for the reviewer
I didn't hash the edge keys in this PR because the edge keys values are heavily used in the tests in test/pipeline/unit/test_connections.py
