### PR TITLE
chore: add sockets docs

### DIFF
--- a/docs/api-docs/component.md
+++ b/docs/api-docs/component.md
@@ -3,3 +3,5 @@
 ::: canals.component
 
 ::: canals.component.component
+
+::: canals.component.sockets


### PR DESCRIPTION
Adds back a reference to the `components.sockets` module for PyDoc to generate the API Documentation for it.