### PR TITLE
Do not use a dict as intermediate format and use `Socket`s directly

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -73,7 +73,7 @@ import inspect
 from typing import Protocol, runtime_checkable, Any
 from types import new_class
 
-
+from canals.component.sockets import InputSocket, OutputSocket
 from canals.errors import ComponentError
 from canals.type_utils import _is_optional
 
@@ -182,7 +182,7 @@ class _Component:
         ```
         """
         instance.__canals_input__ = {
-            name: {"name": name, "type": type_, "is_optional": _is_optional(type_)} for name, type_ in types.items()
+            name: InputSocket(name=name, type=type_, is_optional=_is_optional(type_)) for name, type_ in types.items()
         }
 
     def set_output_types(self, instance, **types):
@@ -205,7 +205,7 @@ class _Component:
                 return {"output_1": 1, "output_2": "2"}
         ```
         """
-        instance.__canals_output__ = {name: {"name": name, "type": type_} for name, type_ in types.items()}
+        instance.__canals_output__ = {name: OutputSocket(name=name, type=type_) for name, type_ in types.items()}
 
     def output_types(self, **types):
         """
@@ -232,7 +232,7 @@ class _Component:
             setattr(
                 run_method,
                 "_output_types_cache",
-                {name: {"name": name, "type": type_} for name, type_ in types.items()},
+                {name: OutputSocket(name=name, type=type_) for name, type_ in types.items()},
             )
             return run_method
 

--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -132,11 +132,11 @@ class ComponentMeta(type):
             run_signature = inspect.signature(getattr(cls, "run"))
             instance.__canals_input__ = {
                 # Create the input sockets
-                param: {
-                    "name": param,
-                    "type": run_signature.parameters[param].annotation,
-                    "is_optional": _is_optional(run_signature.parameters[param].annotation),
-                }
+                param: InputSocket(
+                    name=param,
+                    type=run_signature.parameters[param].annotation,
+                    is_optional=_is_optional(run_signature.parameters[param].annotation),
+                )
                 for param in list(run_signature.parameters)[1:]  # First is 'self' and it doesn't matter.
             }
 

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -214,10 +214,8 @@ class Pipeline:
             )
 
         # Create the component's input and output sockets
-        inputs = getattr(instance, "__canals_input__", {})
-        outputs = getattr(instance, "__canals_output__", {})
-        input_sockets = {name: InputSocket(**data) for name, data in inputs.items()}
-        output_sockets = {name: OutputSocket(**data) for name, data in outputs.items()}
+        input_sockets = getattr(instance, "__canals_input__", {})
+        output_sockets = getattr(instance, "__canals_output__", {})
 
         # Add component to the graph, disconnected
         logger.debug("Adding component '%s' (%s)", name, instance)

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -4,7 +4,7 @@ import pytest
 
 from canals import component
 from canals.errors import ComponentError
-from canals.component import Component
+from canals.component import InputSocket, OutputSocket, Component
 
 
 def test_correct_declaration():
@@ -105,13 +105,7 @@ def test_set_input_types():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp.__canals_input__ == {
-        "value": {
-            "name": "value",
-            "type": Any,
-            "is_optional": False,
-        }
-    }
+    assert comp.__canals_input__ == {"value": InputSocket("value", Any, False)}
     assert comp.run() == {"value": 1}
 
 
@@ -132,12 +126,7 @@ def test_set_output_types():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp.__canals_output__ == {
-        "value": {
-            "name": "value",
-            "type": int,
-        }
-    }
+    assert comp.__canals_output__ == {"value": OutputSocket("value", int)}
 
 
 def test_output_types_decorator_with_compatible_type():
@@ -155,12 +144,7 @@ def test_output_types_decorator_with_compatible_type():
             return cls()
 
     comp = MockComponent()
-    assert comp.__canals_output__ == {
-        "value": {
-            "name": "value",
-            "type": int,
-        }
-    }
+    assert comp.__canals_output__ == {"value": OutputSocket("value", int)}
 
 
 def test_component_decorator_set_it_as_component():

--- a/test/pipeline/integration/test_complex_pipeline.py
+++ b/test/pipeline/integration/test_complex_pipeline.py
@@ -23,17 +23,16 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_complex_pipeline(tmp_path):
-    accumulate = Accumulate()
     loop_merger = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])
     summer = Sum(inputs=["in_1", "in_2", "in_3"])
 
     pipeline = Pipeline(max_loops_allowed=2)
     pipeline.add_component("greet_first", Greet(message="Hello, the value is {value}."))
-    pipeline.add_component("accumulate_1", accumulate)
+    pipeline.add_component("accumulate_1", Accumulate())
     pipeline.add_component("add_two", AddFixedValue(add=2))
     pipeline.add_component("parity", Parity())
     pipeline.add_component("add_one", AddFixedValue(add=1))
-    pipeline.add_component("accumulate_2", accumulate)
+    pipeline.add_component("accumulate_2", Accumulate())
 
     pipeline.add_component("loop_merger", loop_merger)
     pipeline.add_component("below_10", Threshold(threshold=10))
@@ -51,7 +50,7 @@ def test_complex_pipeline(tmp_path):
     pipeline.add_component("replicate", Repeat(outputs=["first", "second"]))
     pipeline.add_component("add_five", AddFixedValue(add=5))
     pipeline.add_component("add_four", AddFixedValue(add=4))
-    pipeline.add_component("accumulate_3", accumulate)
+    pipeline.add_component("accumulate_3", Accumulate())
 
     pipeline.connect("greet_first", "accumulate_1")
     pipeline.connect("accumulate_1", "add_two")
@@ -85,11 +84,7 @@ def test_complex_pipeline(tmp_path):
     pipeline.draw(tmp_path / "complex_pipeline.png")
 
     results = pipeline.run({"greet_first": {"value": 1}, "greet_enumerator": {"value": 1}})
-    pprint(results)
-    print("accumulated: ", accumulate.state)
-
-    assert results == {"accumulate_3": {"value": 9}, "add_five": {"result": -7}}
-    assert accumulate.state == 9
+    assert results == {"accumulate_3": {"value": -7}, "add_five": {"result": -6}}
 
 
 if __name__ == "__main__":

--- a/test/pipeline/integration/test_fixed_merging_pipeline.py
+++ b/test/pipeline/integration/test_fixed_merging_pipeline.py
@@ -13,12 +13,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_pipeline(tmp_path):
-    add_two = AddFixedValue(add=2)
-
     pipeline = Pipeline()
-    pipeline.add_component("first_addition", add_two)
-    pipeline.add_component("second_addition", add_two)
-    pipeline.add_component("third_addition", add_two)
+    pipeline.add_component("first_addition", AddFixedValue(add=2))
+    pipeline.add_component("second_addition", AddFixedValue(add=2))
+    pipeline.add_component("third_addition", AddFixedValue(add=2))
     pipeline.add_component("diff", Subtract())
     pipeline.add_component("fourth_addition", AddFixedValue(add=1))
 

--- a/test/pipeline/integration/test_variable_merging_pipeline.py
+++ b/test/pipeline/integration/test_variable_merging_pipeline.py
@@ -13,14 +13,11 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def test_pipeline(tmp_path):
-    add_two = AddFixedValue(add=2)
-    make_the_sum = Sum(inputs=["in_1", "in_2", "in_3"])
-
     pipeline = Pipeline()
-    pipeline.add_component("first_addition", add_two)
-    pipeline.add_component("second_addition", add_two)
-    pipeline.add_component("third_addition", add_two)
-    pipeline.add_component("sum", make_the_sum)
+    pipeline.add_component("first_addition", AddFixedValue(add=2))
+    pipeline.add_component("second_addition", AddFixedValue(add=2))
+    pipeline.add_component("third_addition", AddFixedValue(add=2))
+    pipeline.add_component("sum", Sum(inputs=["in_1", "in_2", "in_3"]))
     pipeline.add_component("fourth_addition", AddFixedValue(add=1))
 
     pipeline.connect("first_addition.result", "second_addition.value")


### PR DESCRIPTION
Simplify code and remove side effects from sharing a mutable container.