### PR TITLE
Move `is_optional` evaluation for `InputSocket` to `post_init`

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -75,7 +75,6 @@ from types import new_class
 
 from canals.component.sockets import InputSocket, OutputSocket
 from canals.errors import ComponentError
-from canals.type_utils import _is_optional
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +134,6 @@ class ComponentMeta(type):
                 param: InputSocket(
                     name=param,
                     type=run_signature.parameters[param].annotation,
-                    is_optional=_is_optional(run_signature.parameters[param].annotation),
                 )
                 for param in list(run_signature.parameters)[1:]  # First is 'self' and it doesn't matter.
             }
@@ -181,9 +179,7 @@ class _Component:
                 return {"output_1": kwargs["value_1"], "output_2": ""}
         ```
         """
-        instance.__canals_input__ = {
-            name: InputSocket(name=name, type=type_, is_optional=_is_optional(type_)) for name, type_ in types.items()
-        }
+        instance.__canals_input__ = {name: InputSocket(name=name, type=type_) for name, type_ in types.items()}
 
     def set_output_types(self, instance, **types):
         """

--- a/canals/component/sockets.py
+++ b/canals/component/sockets.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
+from typing import Optional, Union, get_origin, get_args
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 logger = logging.getLogger(__name__)
@@ -13,8 +13,11 @@ logger = logging.getLogger(__name__)
 class InputSocket:
     name: str
     type: type
-    is_optional: bool
+    is_optional: bool = field(init=False)
     sender: Optional[str] = None
+
+    def __post_init__(self):
+        self.is_optional = get_origin(self.type) is Union and type(None) in get_args(self.type)
 
 
 @dataclass

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -105,7 +105,7 @@ def test_set_input_types():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp.__canals_input__ == {"value": InputSocket("value", Any, False)}
+    assert comp.__canals_input__ == {"value": InputSocket("value", Any)}
     assert comp.run() == {"value": 1}
 
 

--- a/test/component/test_sockets.py
+++ b/test/component/test_sockets.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from canals.component import InputSocket
+
+
+def test_is_not_optional():
+    s = InputSocket("test_name", int)
+    assert s.is_optional is False
+
+
+def test_is_optional():
+    s = InputSocket("test_name", Optional[int])
+    assert s.is_optional

--- a/test/pipeline/unit/test_pipeline.py
+++ b/test/pipeline/unit/test_pipeline.py
@@ -109,8 +109,8 @@ def test_from_dict():
     add_two = pipe.graph.nodes["add_two"]
     assert add_two["instance"].add == 2
     assert add_two["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender=None),
-        "add": InputSocket(name="add", type=Optional[int], is_optional=True, sender=None),
+        "value": InputSocket(name="value", type=int, sender=None),
+        "add": InputSocket(name="add", type=Optional[int], sender=None),
     }
     assert add_two["output_sockets"] == {
         "result": OutputSocket(name="result", type=int),
@@ -121,8 +121,8 @@ def test_from_dict():
     add_default = pipe.graph.nodes["add_default"]
     assert add_default["instance"].add == 1
     assert add_default["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender="double"),
-        "add": InputSocket(name="add", type=Optional[int], is_optional=True, sender=None),
+        "value": InputSocket(name="value", type=int, sender="double"),
+        "add": InputSocket(name="add", type=Optional[int], sender=None),
     }
     assert add_default["output_sockets"] == {
         "result": OutputSocket(name="result", type=int),
@@ -133,7 +133,7 @@ def test_from_dict():
     double = pipe.graph.nodes["double"]
     assert double["instance"]
     assert double["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender="add_two"),
+        "value": InputSocket(name="value", type=int, sender="add_two"),
     }
     assert double["output_sockets"] == {
         "value": OutputSocket(name="value", type=int),
@@ -149,7 +149,7 @@ def test_from_dict():
         {
             "conn_type": "int",
             "from_socket": OutputSocket(name="result", type=int),
-            "to_socket": InputSocket(name="value", type=int, is_optional=False, sender="add_two"),
+            "to_socket": InputSocket(name="value", type=int, sender="add_two"),
         },
     )
     assert connections[1] == (
@@ -158,7 +158,7 @@ def test_from_dict():
         {
             "conn_type": "int",
             "from_socket": OutputSocket(name="value", type=int),
-            "to_socket": InputSocket(name="value", type=int, is_optional=False, sender="double"),
+            "to_socket": InputSocket(name="value", type=int, sender="double"),
         },
     )
 
@@ -201,8 +201,8 @@ def test_from_dict_with_components_instances():
     assert add_two_data["instance"] is add_two
     assert add_two_data["instance"].add == 2
     assert add_two_data["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender=None),
-        "add": InputSocket(name="add", type=Optional[int], is_optional=True, sender=None),
+        "value": InputSocket(name="value", type=int, sender=None),
+        "add": InputSocket(name="add", type=Optional[int], sender=None),
     }
     assert add_two_data["output_sockets"] == {
         "result": OutputSocket(name="result", type=int),
@@ -214,8 +214,8 @@ def test_from_dict_with_components_instances():
     assert add_default_data["instance"] is add_default
     assert add_default_data["instance"].add == 1
     assert add_default_data["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender="double"),
-        "add": InputSocket(name="add", type=Optional[int], is_optional=True, sender=None),
+        "value": InputSocket(name="value", type=int, sender="double"),
+        "add": InputSocket(name="add", type=Optional[int], sender=None),
     }
     assert add_default_data["output_sockets"] == {
         "result": OutputSocket(name="result", type=int),
@@ -226,7 +226,7 @@ def test_from_dict_with_components_instances():
     double = pipe.graph.nodes["double"]
     assert double["instance"]
     assert double["input_sockets"] == {
-        "value": InputSocket(name="value", type=int, is_optional=False, sender="add_two"),
+        "value": InputSocket(name="value", type=int, sender="add_two"),
     }
     assert double["output_sockets"] == {
         "value": OutputSocket(name="value", type=int),
@@ -242,7 +242,7 @@ def test_from_dict_with_components_instances():
         {
             "conn_type": "int",
             "from_socket": OutputSocket(name="result", type=int),
-            "to_socket": InputSocket(name="value", type=int, is_optional=False, sender="add_two"),
+            "to_socket": InputSocket(name="value", type=int, sender="add_two"),
         },
     )
     assert connections[1] == (
@@ -251,7 +251,7 @@ def test_from_dict_with_components_instances():
         {
             "conn_type": "int",
             "from_socket": OutputSocket(name="value", type=int),
-            "to_socket": InputSocket(name="value", type=int, is_optional=False, sender="double"),
+            "to_socket": InputSocket(name="value", type=int, sender="double"),
         },
     )
 

--- a/test/pipeline/unit/test_validation_pipeline_io.py
+++ b/test/pipeline/unit/test_validation_pipeline_io.py
@@ -27,7 +27,7 @@ def test_find_pipeline_input_one_input():
     pipe.connect("comp1", "comp2")
 
     assert _find_pipeline_inputs(pipe.graph) == {
-        "comp1": [InputSocket(name="value", type=int, is_optional=False)],
+        "comp1": [InputSocket(name="value", type=int)],
         "comp2": [],
     }
 
@@ -40,8 +40,8 @@ def test_find_pipeline_input_two_inputs_same_component():
 
     assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
-            InputSocket(name="value", type=int, is_optional=False),
-            InputSocket(name="add", type=Optional[int], is_optional=True),
+            InputSocket(name="value", type=int),
+            InputSocket(name="add", type=Optional[int]),
         ],
         "comp2": [],
     }
@@ -57,10 +57,10 @@ def test_find_pipeline_input_some_inputs_different_components():
 
     assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
-            InputSocket(name="value", type=int, is_optional=False),
-            InputSocket(name="add", type=Optional[int], is_optional=True),
+            InputSocket(name="value", type=int),
+            InputSocket(name="add", type=Optional[int]),
         ],
-        "comp2": [InputSocket(name="value", type=int, is_optional=False)],
+        "comp2": [InputSocket(name="value", type=int)],
         "comp3": [],
     }
 
@@ -73,13 +73,13 @@ def test_find_pipeline_variable_input_nodes_in_the_pipeline():
 
     assert _find_pipeline_inputs(pipe.graph) == {
         "comp1": [
-            InputSocket(name="value", type=int, is_optional=False),
-            InputSocket(name="add", type=Optional[int], is_optional=True),
+            InputSocket(name="value", type=int),
+            InputSocket(name="add", type=Optional[int]),
         ],
-        "comp2": [InputSocket(name="value", type=int, is_optional=False)],
+        "comp2": [InputSocket(name="value", type=int)],
         "comp3": [
-            InputSocket(name="in_1", type=Optional[int], is_optional=True),
-            InputSocket(name="in_2", type=Optional[int], is_optional=True),
+            InputSocket(name="in_1", type=Optional[int]),
+            InputSocket(name="in_2", type=Optional[int]),
         ],
     }
 


### PR DESCRIPTION
The dataclass can take care of determining the type, let's make the caller code less verbose