### PR TITLE
Properly annotate classmethods

### DIFF
--- a/canals/__init__.py
+++ b/canals/__init__.py
@@ -5,3 +5,5 @@ from canals.__about__ import __version__
 
 from canals.component import component, Component
 from canals.pipeline.pipeline import Pipeline
+
+__all__ = ["component", "Component", "Pipeline"]


### PR DESCRIPTION
Annotate the return type of `classmethods` with a generic type bounded to `canals.Pipeline`. This way, when derived classes need to return `cls` (e.g. other classmethods) mypy will understand what's going on.