### PR TITLE
tests: Add self-loop integration test

### DIFF
--- a/sample_components/__init__.py
+++ b/sample_components/__init__.py
@@ -16,6 +16,7 @@ from sample_components.merge_loop import MergeLoop
 from sample_components.joiner import StringJoiner, StringListJoiner
 from sample_components.hello import Hello
 from sample_components.text_splitter import TextSplitter
+from sample_components.self_loop import SelfLoop
 
 __all__ = [
     "Concatenate",
@@ -34,4 +35,5 @@ __all__ = [
     "Hello",
     "TextSplitter",
     "StringListJoiner",
+    "SelfLoop",
 ]

--- a/sample_components/self_loop.py
+++ b/sample_components/self_loop.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from canals import component
+
+
+@component
+class SelfLoop:
+    """
+    Decreases the initial value in steps of 1 until the target value is reached.
+    For no good reason it uses a self-loop to do so :)
+    """
+
+    def __init__(self, target: int = 0):
+        self.target = target
+
+    @component.output_types(current_value=int, final_result=int)
+    def run(self, initial_value: Optional[int] = None, current_value: Optional[int] = None):
+        """
+        Decreases the initial value in steps of 1 until the target value is reached.
+        """
+        if initial_value:
+            current_value = initial_value
+
+        if current_value:
+            current_value -= 1
+
+        if current_value == self.target:
+            return {"final_result": current_value}
+        return {"current_value": current_value}

--- a/test/pipeline/integration/test_self_loop_pipelines.py
+++ b/test/pipeline/integration/test_self_loop_pipelines.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+from pathlib import Path
+from pprint import pprint
+
+from canals import component
+from canals.pipeline import Pipeline
+from sample_components import AddFixedValue, SelfLoop
+
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def test_pipeline_one_node(tmp_path):
+    pipeline = Pipeline(max_loops_allowed=10)
+    pipeline.add_component("self_loop", SelfLoop())
+    pipeline.connect("self_loop.current_value", "self_loop.current_value")
+
+    pipeline.draw(tmp_path / "self_looping_pipeline_one_node.png")
+
+    results = pipeline.run({"self_loop": {"initial_value": 5}})
+    pprint(results)
+
+    assert results["self_loop"]["final_result"] == 0
+
+
+def test_pipeline(tmp_path):
+    pipeline = Pipeline(max_loops_allowed=10)
+    pipeline.add_component("add_1", AddFixedValue())
+    pipeline.add_component("self_loop", SelfLoop())
+    pipeline.add_component("add_2", AddFixedValue())
+    pipeline.connect("add_1", "self_loop.initial_value")
+    pipeline.connect("self_loop.current_value", "self_loop.current_value")
+    pipeline.connect("self_loop.final_result", "add_2.value")
+
+    pipeline.draw(tmp_path / "self_looping_pipeline.png")
+
+    results = pipeline.run({"add_1": {"value": 5}})
+    pprint(results)
+
+    assert results["add_2"]["result"] == 1
+
+
+if __name__ == "__main__":
+    test_pipeline_one_node(Path(__file__).parent)
+    test_pipeline(Path(__file__).parent)


### PR DESCRIPTION
Adds two integration tests for pipelines with component that have a self-loop.

### First test case 

![self_looping_pipeline_one_node](https://github.com/deepset-ai/canals/assets/5703634/d3d01308-2f31-40da-bee6-92d7cafa99ce)

### Second test case

![self_looping_pipeline](https://github.com/deepset-ai/canals/assets/5703634/06b81c17-ee67-4672-841b-73fb58b79d2a)
