### PR TITLE
feat: Add component inputs/outputs methods

### DIFF
--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,4 +1,5 @@
-from typing import Any
+import typing
+from typing import Any, Optional
 
 import pytest
 
@@ -163,3 +164,133 @@ def test_component_decorator_set_it_as_component():
 
     comp = MockComponent()
     assert isinstance(comp, Component)
+
+
+def test_inputs_method_no_inputs():
+    @component
+    class MockComponent:
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {}
+
+
+def test_inputs_method_one_input():
+    @component
+    class MockComponent:
+        def run(self, value: int):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {"value": {"is_optional": False, "type": int}}
+
+
+def test_inputs_method_multiple_inputs():
+    @component
+    class MockComponent:
+        def run(self, value1: int, value2: str):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {
+        "value1": {"is_optional": False, "type": int},
+        "value2": {"is_optional": False, "type": str},
+    }
+
+
+def test_inputs_method_multiple_inputs_optional():
+    @component
+    class MockComponent:
+        def run(self, value1: int, value2: Optional[str]):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {
+        "value1": {"is_optional": False, "type": int},
+        "value2": {"is_optional": True, "type": typing.Optional[str]},
+    }
+
+
+def test_inputs_method_variadic_positional_args():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=Any)
+
+        def run(self, *args):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {"value": {"is_optional": False, "type": typing.Any}}
+
+
+def test_inputs_method_variadic_keyword_positional_args():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=Any)
+
+        def run(self, **kwargs):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {"value": {"is_optional": False, "type": typing.Any}}
+
+
+def test_inputs_dynamic_from_init():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=int)
+
+        def run(self, value: int, **kwargs):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.inputs() == {"value": {"is_optional": False, "type": int}}
+
+
+def test_outputs_method_no_outputs():
+    @component
+    class MockComponent:
+        def run(self):
+            return {}
+
+    comp = MockComponent()
+    assert comp.outputs() == {}
+
+
+def test_outputs_method_one_output():
+    @component
+    class MockComponent:
+        @component.output_types(value=int)
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.outputs() == {"value": {"type": int}}
+
+
+def test_outputs_method_multiple_outputs():
+    @component
+    class MockComponent:
+        @component.output_types(value1=int, value2=str)
+        def run(self):
+            return {"value1": 1, "value2": "test"}
+
+    comp = MockComponent()
+    assert comp.outputs() == {"value1": {"type": int}, "value2": {"type": str}}
+
+
+def test_outputs_dynamic_from_init():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_output_types(self, value=int)
+
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp.outputs() == {"value": {"type": int}}


### PR DESCRIPTION
### Why:
To enable introspection of Canals components, namely the ability to retrieve information about component inputs and outputs programmatically.

### What:
Two methods, `inputs` and `outputs`, have been dynamically attached to component instances, allowing for the retrieval of input and output socket details, respectively.

### How can it be used:
Once this PR is merged, Canals component instances will have `inputs` and `outputs` methods available:

```python
component_instance = SomeComponent()  # instantiate a Canals component
input_details = component_instance.inputs()  # get details of input sockets
output_details = component_instance.outputs()  # get details of output sockets
```

The `inputs` method returns a dictionary where each key is an input socket name while values are its type and optionality, and the `outputs` method similarly returns a dictionary mapping output socket names to their types.

### How did you test it:
Unit tests have been added to `test/component/test_component.py` to verify that the `inputs` and `outputs` methods function as expected, providing the correct details for each socket.

### Notes for reviewer:
Please verify the implementation of the dynamic attachment of `inputs` and `outputs` and if test coverage is sufficient. 
