### PR TITLE
Add missing `typing_extensions` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dynamic = ["version"]
 dependencies = [
   "networkx", # Pipeline graphs
   "requests", # Mermaid diagrams
+  "typing_extensions",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`typing_extensions` is used but is missing from dependencies, both explicit and transient.

Error:
```
>>> from canals import component
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/silvanocerza/workspace/canals/canals/__init__.py", line 6, in <module>
    from canals.component import component, Component
  File "/Users/silvanocerza/workspace/canals/canals/component/__init__.py", line 4, in <module>
    from canals.component.component import component, Component
  File "/Users/silvanocerza/workspace/canals/canals/component/component.py", line 76, in <module>
    from canals.component.sockets import InputSocket, OutputSocket
  File "/Users/silvanocerza/workspace/canals/canals/component/sockets.py", line 8, in <module>
    from canals.component.types import CANALS_VARIADIC_ANNOTATION
  File "/Users/silvanocerza/workspace/canals/canals/component/types.py", line 2, in <module>
    from typing_extensions import TypeAlias, Annotated  # Python 3.8 compatibility
ModuleNotFoundError: No module named 'typing_extensions'
```