### PR TITLE
Make `Sum` Variadic

### DIFF
--- a/sample_components/sum.py
+++ b/sample_components/sum.py
@@ -1,20 +1,15 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, List
-
 from canals import component
+from canals.component.types import Variadic
 
 
 @component
 class Sum:
-    def __init__(self, inputs: List[str]):
-        self.inputs = inputs
-        component.set_input_types(self, **{input_name: Optional[int] for input_name in inputs})
-
     @component.output_types(total=int)
-    def run(self, **kwargs):
+    def run(self, values: Variadic[int]):
         """
         :param value: the value to check the remainder of.
         """
-        return {"total": sum(kwargs.values())}
+        return {"total": sum(values)}  # type: ignore

--- a/test/pipeline/integration/test_complex_pipeline.py
+++ b/test/pipeline/integration/test_complex_pipeline.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 def test_complex_pipeline(tmp_path):
     loop_merger = MergeLoop(expected_type=int, inputs=["in_1", "in_2"])
-    summer = Sum(inputs=["in_1", "in_2", "in_3"])
+    summer = Sum()
 
     pipeline = Pipeline(max_loops_allowed=2)
     pipeline.add_component("greet_first", Greet(message="Hello, the value is {value}."))
@@ -56,7 +56,7 @@ def test_complex_pipeline(tmp_path):
     pipeline.connect("add_two", "parity")
 
     pipeline.connect("parity.even", "greet_again")
-    pipeline.connect("greet_again", "sum.in_1")
+    pipeline.connect("greet_again", "sum.values")
     pipeline.connect("sum", "diff.first_value")
     pipeline.connect("diff", "greet_one_last_time")
     pipeline.connect("greet_one_last_time", "replicate")
@@ -75,10 +75,10 @@ def test_complex_pipeline(tmp_path):
     pipeline.connect("accumulate_2", "diff.second_value")
 
     pipeline.connect("greet_enumerator", "enumerate")
-    pipeline.connect("enumerate.second", "sum.in_2")
+    pipeline.connect("enumerate.second", "sum.values")
 
     pipeline.connect("enumerate.first", "add_three.value")
-    pipeline.connect("add_three", "sum.in_3")
+    pipeline.connect("add_three", "sum.values")
 
     pipeline.draw(tmp_path / "complex_pipeline.png")
 

--- a/test/pipeline/integration/test_looping_and_merge_pipeline.py
+++ b/test/pipeline/integration/test_looping_and_merge_pipeline.py
@@ -18,7 +18,7 @@ def test_pipeline_fixed(tmp_path):
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("add_zero", AddFixedValue(add=0))
     pipeline.add_component("merge", MergeLoop(expected_type=int, inputs=["in_1", "in_2"]))
-    pipeline.add_component("sum", Sum(inputs=["in_1", "in_2"]))
+    pipeline.add_component("sum", Sum())
     pipeline.add_component("below_10", Threshold(threshold=10))
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("counter", accumulator)
@@ -30,12 +30,12 @@ def test_pipeline_fixed(tmp_path):
     pipeline.connect("add_one.result", "counter.value")
     pipeline.connect("counter.value", "merge.in_2")
     pipeline.connect("below_10.above", "add_two.value")
-    pipeline.connect("add_two.result", "sum.in_2")
+    pipeline.connect("add_two.result", "sum.values")
 
     pipeline.draw(tmp_path / "looping_and_fixed_merge_pipeline.png")
 
     results = pipeline.run(
-        {"add_zero": {"value": 8}, "sum": {"in_1": 2}},
+        {"add_zero": {"value": 8}, "sum": {"values": 2}},
     )
     pprint(results)
     print("accumulate: ", accumulator.state)
@@ -49,7 +49,7 @@ def test_pipeline_variadic(tmp_path):
     pipeline = Pipeline(max_loops_allowed=10)
     pipeline.add_component("add_zero", AddFixedValue(add=0))
     pipeline.add_component("merge", FirstIntSelector())
-    pipeline.add_component("sum", Sum(inputs=["in_1", "in_2"]))
+    pipeline.add_component("sum", Sum())
     pipeline.add_component("below_10", Threshold(threshold=10))
     pipeline.add_component("add_one", AddFixedValue(add=1))
     pipeline.add_component("counter", accumulator)
@@ -61,12 +61,12 @@ def test_pipeline_variadic(tmp_path):
     pipeline.connect("add_one.result", "counter.value")
     pipeline.connect("counter.value", "merge.inputs")
     pipeline.connect("below_10.above", "add_two.value")
-    pipeline.connect("add_two.result", "sum.in_2")
+    pipeline.connect("add_two.result", "sum.values")
 
     pipeline.draw(tmp_path / "looping_and_variadic_merge_pipeline.png")
 
     results = pipeline.run(
-        {"add_zero": {"value": 8}, "sum": {"in_1": 2}},
+        {"add_zero": {"value": 8}, "sum": {"values": 2}},
     )
     pprint(results)
     print("accumulate: ", accumulator.state)

--- a/test/pipeline/integration/test_variable_decision_and_merge_pipeline.py
+++ b/test/pipeline/integration/test_variable_decision_and_merge_pipeline.py
@@ -19,17 +19,17 @@ def test_pipeline(tmp_path):
     pipeline.add_component("double", Double())
     pipeline.add_component("add_four", AddFixedValue(add=4))
     pipeline.add_component("add_one_again", AddFixedValue())
-    pipeline.add_component("sum", Sum(inputs=["in_1", "in_2", "in_3", "in_4"]))
+    pipeline.add_component("sum", Sum())
 
     pipeline.connect("add_one.result", "parity.value")
     pipeline.connect("parity.remainder_is_0", "add_ten.value")
     pipeline.connect("parity.remainder_is_1", "double.value")
-    pipeline.connect("add_one.result", "sum.in_1")
-    pipeline.connect("add_ten.result", "sum.in_2")
-    pipeline.connect("double.value", "sum.in_3")
+    pipeline.connect("add_one.result", "sum.values")
+    pipeline.connect("add_ten.result", "sum.values")
+    pipeline.connect("double.value", "sum.values")
     pipeline.connect("parity.remainder_is_1", "add_four.value")
     pipeline.connect("add_four.result", "add_one_again.value")
-    pipeline.connect("add_one_again.result", "sum.in_4")
+    pipeline.connect("add_one_again.result", "sum.values")
 
     pipeline.draw(tmp_path / "variable_decision_and_merge_pipeline.png")
 

--- a/test/pipeline/integration/test_variable_merging_pipeline.py
+++ b/test/pipeline/integration/test_variable_merging_pipeline.py
@@ -17,13 +17,13 @@ def test_pipeline(tmp_path):
     pipeline.add_component("first_addition", AddFixedValue(add=2))
     pipeline.add_component("second_addition", AddFixedValue(add=2))
     pipeline.add_component("third_addition", AddFixedValue(add=2))
-    pipeline.add_component("sum", Sum(inputs=["in_1", "in_2", "in_3"]))
+    pipeline.add_component("sum", Sum())
     pipeline.add_component("fourth_addition", AddFixedValue(add=1))
 
     pipeline.connect("first_addition.result", "second_addition.value")
-    pipeline.connect("first_addition.result", "sum.in_1")
-    pipeline.connect("second_addition.result", "sum.in_2")
-    pipeline.connect("third_addition.result", "sum.in_3")
+    pipeline.connect("first_addition.result", "sum.values")
+    pipeline.connect("second_addition.result", "sum.values")
+    pipeline.connect("third_addition.result", "sum.values")
     pipeline.connect("sum.total", "fourth_addition.value")
 
     pipeline.draw(tmp_path / "variable_merging_pipeline.png")

--- a/test/pipeline/unit/test_validation_pipeline_io.py
+++ b/test/pipeline/unit/test_validation_pipeline_io.py
@@ -5,6 +5,7 @@ import inspect
 
 from canals.pipeline import Pipeline
 from canals.errors import PipelineValidationError
+from canals.component.types import Variadic
 from canals.component.sockets import InputSocket, OutputSocket
 from canals.pipeline.descriptions import find_pipeline_inputs, find_pipeline_outputs
 from sample_components import Double, AddFixedValue, Sum, Parity
@@ -66,7 +67,7 @@ def test_find_pipeline_variable_input_nodes_in_the_pipeline():
     pipe = Pipeline()
     pipe.add_component("comp1", AddFixedValue())
     pipe.add_component("comp2", Double())
-    pipe.add_component("comp3", Sum(inputs=["in_1", "in_2"]))
+    pipe.add_component("comp3", Sum())
 
     assert find_pipeline_inputs(pipe.graph) == {
         "comp1": [
@@ -75,8 +76,7 @@ def test_find_pipeline_variable_input_nodes_in_the_pipeline():
         ],
         "comp2": [InputSocket(name="value", type=int)],
         "comp3": [
-            InputSocket(name="in_1", type=Optional[int]),
-            InputSocket(name="in_2", type=Optional[int]),
+            InputSocket(name="values", type=Variadic[int]),
         ],
     }
 

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -7,50 +7,28 @@ from canals.serialization import component_to_dict, component_from_dict
 
 
 def test_to_dict():
-    component = Sum(inputs=["first", "second"])
+    component = Sum()
     res = component_to_dict(component)
-    assert res == {"type": "Sum", "init_parameters": {"inputs": ["first", "second"]}}
+    assert res == {"type": "Sum", "init_parameters": {}}
 
 
 def test_from_dict():
-    data = {"type": "Sum", "init_parameters": {"inputs": ["first", "second"]}}
+    data = {"type": "Sum", "init_parameters": {}}
     component = component_from_dict(Sum, data)
-    assert component.inputs == ["first", "second"]
+    assert isinstance(component, Sum)
 
 
-def test_sum_expects_no_values_receives_no_values():
-    component = Sum(inputs=[])
-    results = component.run()
+def test_sum_receives_no_values():
+    component = Sum()
+    results = component.run(values=[])
     assert results == {"total": 0}
 
 
-def test_sum_expects_no_values_receives_one_value():
-    component = Sum(inputs=[])
-    assert component.run(value_1=10) == {"total": 10}
+def test_sum_receives_one_value():
+    component = Sum()
+    assert component.run(values=[10]) == {"total": 10}
 
 
-def test_sum_expects_one_value_receives_one_value():
-    component = Sum(inputs=["value_1"])
-    results = component.run(value_1=10)
-    assert results == {"total": 10}
-
-
-def test_sum_expects_one_value_receives_wrong_value():
-    component = Sum(inputs=["value_1"])
-    assert component.run(something_else=10) == {"total": 10}
-
-
-def test_sum_expects_one_value_receives_few_values():
-    component = Sum(inputs=["value_1"])
-    assert component.run(value_1=10, value_2=2) == {"total": 12}
-
-
-def test_sum_expects_few_values_receives_right_values():
-    component = Sum(inputs=["value_1", "value_2", "value_3"])
-    results = component.run(value_1=10, value_2=11, value_3=12)
-    assert results == {"total": 33}
-
-
-def test_sum_expects_few_values_receives_some_wrong_values():
-    component = Sum(inputs=["value_1", "value_2", "value_3"])
-    assert component.run(value_1=10, value_4=11, value_3=12) == {"total": 33}
+def test_sum_receives_few_values():
+    component = Sum()
+    assert component.run(values=[10, 2]) == {"total": 12}


### PR DESCRIPTION
Changes the `Sum` sample component have a single `Variadic` input value called `values` instead of a dynamic number of `Optional` inputs.

---

This change unfortunately breaks more integration tests. Fixing it requires changes to the run() method which are going to be addressed in a separate PR.