### PR TITLE
feat: Add Component inputs/outputs functions

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -70,7 +70,6 @@
 
 import logging
 import inspect
-import types
 from typing import Protocol, runtime_checkable, Any
 from types import new_class
 
@@ -138,21 +137,6 @@ class ComponentMeta(type):
                 )
                 for param in list(run_signature.parameters)[1:]  # First is 'self' and it doesn't matter.
             }
-
-        # Dynamically attach the inputs method to instance, not class
-        def inputs_method(self):
-            return {
-                name: {"type": socket.type, "is_optional": socket.is_optional}
-                for name, socket in self.__canals_input__.items()
-            }
-
-        instance._input_sockets = types.MethodType(inputs_method, instance)
-
-        # Dynamically attach the outputs method to instance, not class
-        def outputs_method(self):
-            return {name: {"type": socket.type} for name, socket in self.__canals_output__.items()}
-
-        instance._output_sockets = types.MethodType(outputs_method, instance)
 
         return instance
 

--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -70,6 +70,7 @@
 
 import logging
 import inspect
+import types
 from typing import Protocol, runtime_checkable, Any
 from types import new_class
 
@@ -137,6 +138,21 @@ class ComponentMeta(type):
                 )
                 for param in list(run_signature.parameters)[1:]  # First is 'self' and it doesn't matter.
             }
+
+        # Dynamically attach the inputs method to instance, not class
+        def inputs_method(self):
+            return {
+                name: {"type": socket.type, "is_optional": socket.is_optional}
+                for name, socket in self.__canals_input__.items()
+            }
+
+        instance._input_sockets = types.MethodType(inputs_method, instance)
+
+        # Dynamically attach the outputs method to instance, not class
+        def outputs_method(self):
+            return {name: {"type": socket.type} for name, socket in self.__canals_output__.items()}
+
+        instance._output_sockets = types.MethodType(outputs_method, instance)
 
         return instance
 

--- a/canals/component/descriptions.py
+++ b/canals/component/descriptions.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any
 
 
-def component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
+def find_component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
     """
     Returns a mapping of input names to their expected types and optionality for a given component.
 
@@ -23,7 +23,7 @@ def component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
     }
 
 
-def component_outputs(component: Any) -> Dict[str, Dict[str, Any]]:
+def find_component_outputs(component: Any) -> Dict[str, Dict[str, Any]]:
     """
     Returns a mapping of component output names to their expected types.
 

--- a/canals/component/descriptions.py
+++ b/canals/component/descriptions.py
@@ -12,8 +12,10 @@ def component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
     :raise: Throws a ValueError if the class of component instance is not appropriately decorated with @component.
     """
     if not hasattr(component, "__canals_input__"):
-        raise ValueError(f"Component {component} does not have defined inputs or is improperly decorated. "
-                         "Ensure it is a valid @component with declared inputs.")
+        raise ValueError(
+            f"Component {component} does not have defined inputs or is improperly decorated. "
+            "Ensure it is a valid @component with declared inputs."
+        )
 
     return {
         name: {"type": socket.type, "is_optional": socket.is_optional}
@@ -34,6 +36,7 @@ def component_outputs(component: Any) -> Dict[str, Dict[str, Any]]:
     if not hasattr(component, "__canals_output__"):
         raise ValueError(
             f"The specified component {component} does not have defined outputs or is not properly decorated. "
-            "Check that it is a valid @component with outputs specified.")
+            "Check that it is a valid @component with outputs specified."
+        )
 
     return {name: {"type": socket.type} for name, socket in component.__canals_output__.items()}

--- a/canals/component/descriptions.py
+++ b/canals/component/descriptions.py
@@ -1,0 +1,39 @@
+from typing import Dict, Any
+
+
+def component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
+    """
+    Returns a mapping of input names to their expected types and optionality for a given component.
+
+    :param component: The target component to introspect.
+    :return: A dictionary where keys are input names, with each key's value being another dictionary
+    containing 'type' (the data type expected) and 'is_optional' (a boolean indicating if the input is optional).
+
+    :raise: Throws a ValueError if the class of component instance is not appropriately decorated with @component.
+    """
+    if not hasattr(component, "__canals_input__"):
+        raise ValueError(f"Component {component} does not have defined inputs or is improperly decorated. "
+                         "Ensure it is a valid @component with declared inputs.")
+
+    return {
+        name: {"type": socket.type, "is_optional": socket.is_optional}
+        for name, socket in component.__canals_input__.items()
+    }
+
+
+def component_outputs(component: Any) -> Dict[str, Dict[str, Any]]:
+    """
+    Returns a mapping of component output names to their expected types.
+
+    :param component: The component being examined for its outputs.
+    :return: A dictionary where each key is an output name and the value is a dictionary with a 'type' key
+    indicating the data type of the output.
+
+    :raise: Throws a ValueError if the class of component instance is not appropriately decorated with @component.
+    """
+    if not hasattr(component, "__canals_output__"):
+        raise ValueError(
+            f"The specified component {component} does not have defined outputs or is not properly decorated. "
+            "Check that it is a valid @component with outputs specified.")
+
+    return {name: {"type": socket.type} for name, socket in component.__canals_output__.items()}

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -1,4 +1,5 @@
-from typing import Any
+import typing
+from typing import Any, Optional
 
 import pytest
 
@@ -163,3 +164,133 @@ def test_component_decorator_set_it_as_component():
 
     comp = MockComponent()
     assert isinstance(comp, Component)
+
+
+def test_inputs_method_no_inputs():
+    @component
+    class MockComponent:
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {}
+
+
+def test_inputs_method_one_input():
+    @component
+    class MockComponent:
+        def run(self, value: int):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {"value": {"is_optional": False, "type": int}}
+
+
+def test_inputs_method_multiple_inputs():
+    @component
+    class MockComponent:
+        def run(self, value1: int, value2: str):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {
+        "value1": {"is_optional": False, "type": int},
+        "value2": {"is_optional": False, "type": str},
+    }
+
+
+def test_inputs_method_multiple_inputs_optional():
+    @component
+    class MockComponent:
+        def run(self, value1: int, value2: Optional[str]):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {
+        "value1": {"is_optional": False, "type": int},
+        "value2": {"is_optional": True, "type": typing.Optional[str]},
+    }
+
+
+def test_inputs_method_variadic_positional_args():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=Any)
+
+        def run(self, *args):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {"value": {"is_optional": False, "type": typing.Any}}
+
+
+def test_inputs_method_variadic_keyword_positional_args():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=Any)
+
+        def run(self, **kwargs):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {"value": {"is_optional": False, "type": typing.Any}}
+
+
+def test_inputs_dynamic_from_init():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_input_types(self, value=int)
+
+        def run(self, value: int, **kwargs):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._input_sockets() == {"value": {"is_optional": False, "type": int}}
+
+
+def test_outputs_method_no_outputs():
+    @component
+    class MockComponent:
+        def run(self):
+            return {}
+
+    comp = MockComponent()
+    assert comp._output_sockets() == {}
+
+
+def test_outputs_method_one_output():
+    @component
+    class MockComponent:
+        @component.output_types(value=int)
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._output_sockets() == {"value": {"type": int}}
+
+
+def test_outputs_method_multiple_outputs():
+    @component
+    class MockComponent:
+        @component.output_types(value1=int, value2=str)
+        def run(self):
+            return {"value1": 1, "value2": "test"}
+
+    comp = MockComponent()
+    assert comp._output_sockets() == {"value1": {"type": int}, "value2": {"type": str}}
+
+
+def test_outputs_dynamic_from_init():
+    @component
+    class MockComponent:
+        def __init__(self):
+            component.set_output_types(self, value=int)
+
+        def run(self):
+            return {"value": 1}
+
+    comp = MockComponent()
+    assert comp._output_sockets() == {"value": {"type": int}}

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -4,7 +4,7 @@ from typing import Any, Optional
 import pytest
 
 from canals import component
-from canals.component.descriptions import component_inputs, component_outputs
+from canals.component.descriptions import find_component_inputs, find_component_outputs
 from canals.errors import ComponentError
 from canals.component import InputSocket, OutputSocket, Component
 
@@ -174,7 +174,7 @@ def test_inputs_method_no_inputs():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {}
+    assert find_component_inputs(comp) == {}
 
 
 def test_inputs_method_one_input():
@@ -184,7 +184,7 @@ def test_inputs_method_one_input():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
+    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
 
 
 def test_inputs_method_multiple_inputs():
@@ -194,7 +194,7 @@ def test_inputs_method_multiple_inputs():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {
+    assert find_component_inputs(comp) == {
         "value1": {"is_optional": False, "type": int},
         "value2": {"is_optional": False, "type": str},
     }
@@ -207,7 +207,7 @@ def test_inputs_method_multiple_inputs_optional():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {
+    assert find_component_inputs(comp) == {
         "value1": {"is_optional": False, "type": int},
         "value2": {"is_optional": True, "type": typing.Optional[str]},
     }
@@ -223,7 +223,7 @@ def test_inputs_method_variadic_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
+    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
 
 
 def test_inputs_method_variadic_keyword_positional_args():
@@ -236,7 +236,7 @@ def test_inputs_method_variadic_keyword_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
+    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
 
 
 def test_inputs_dynamic_from_init():
@@ -249,7 +249,7 @@ def test_inputs_dynamic_from_init():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
+    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
 
 
 def test_outputs_method_no_outputs():
@@ -259,7 +259,7 @@ def test_outputs_method_no_outputs():
             return {}
 
     comp = MockComponent()
-    assert component_outputs(comp) == {}
+    assert find_component_outputs(comp) == {}
 
 
 def test_outputs_method_one_output():
@@ -270,7 +270,7 @@ def test_outputs_method_one_output():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_outputs(comp) == {"value": {"type": int}}
+    assert find_component_outputs(comp) == {"value": {"type": int}}
 
 
 def test_outputs_method_multiple_outputs():
@@ -281,7 +281,7 @@ def test_outputs_method_multiple_outputs():
             return {"value1": 1, "value2": "test"}
 
     comp = MockComponent()
-    assert component_outputs(comp) == {"value1": {"type": int}, "value2": {"type": str}}
+    assert find_component_outputs(comp) == {"value1": {"type": int}, "value2": {"type": str}}
 
 
 def test_outputs_dynamic_from_init():
@@ -294,4 +294,4 @@ def test_outputs_dynamic_from_init():
             return {"value": 1}
 
     comp = MockComponent()
-    assert component_outputs(comp) == {"value": {"type": int}}
+    assert find_component_outputs(comp) == {"value": {"type": int}}

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 import pytest
 
 from canals import component
+from canals.component.descriptions import component_inputs, component_outputs
 from canals.errors import ComponentError
 from canals.component import InputSocket, OutputSocket, Component
 
@@ -173,7 +174,7 @@ def test_inputs_method_no_inputs():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {}
+    assert component_inputs(comp) == {}
 
 
 def test_inputs_method_one_input():
@@ -183,7 +184,7 @@ def test_inputs_method_one_input():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {"value": {"is_optional": False, "type": int}}
+    assert component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
 
 
 def test_inputs_method_multiple_inputs():
@@ -193,7 +194,7 @@ def test_inputs_method_multiple_inputs():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {
+    assert component_inputs(comp) == {
         "value1": {"is_optional": False, "type": int},
         "value2": {"is_optional": False, "type": str},
     }
@@ -206,7 +207,7 @@ def test_inputs_method_multiple_inputs_optional():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {
+    assert component_inputs(comp) == {
         "value1": {"is_optional": False, "type": int},
         "value2": {"is_optional": True, "type": typing.Optional[str]},
     }
@@ -222,7 +223,7 @@ def test_inputs_method_variadic_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {"value": {"is_optional": False, "type": typing.Any}}
+    assert component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
 
 
 def test_inputs_method_variadic_keyword_positional_args():
@@ -235,7 +236,7 @@ def test_inputs_method_variadic_keyword_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {"value": {"is_optional": False, "type": typing.Any}}
+    assert component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
 
 
 def test_inputs_dynamic_from_init():
@@ -248,7 +249,7 @@ def test_inputs_dynamic_from_init():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._input_sockets() == {"value": {"is_optional": False, "type": int}}
+    assert component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
 
 
 def test_outputs_method_no_outputs():
@@ -258,7 +259,7 @@ def test_outputs_method_no_outputs():
             return {}
 
     comp = MockComponent()
-    assert comp._output_sockets() == {}
+    assert component_outputs(comp) == {}
 
 
 def test_outputs_method_one_output():
@@ -269,7 +270,7 @@ def test_outputs_method_one_output():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._output_sockets() == {"value": {"type": int}}
+    assert component_outputs(comp) == {"value": {"type": int}}
 
 
 def test_outputs_method_multiple_outputs():
@@ -280,7 +281,7 @@ def test_outputs_method_multiple_outputs():
             return {"value1": 1, "value2": "test"}
 
     comp = MockComponent()
-    assert comp._output_sockets() == {"value1": {"type": int}, "value2": {"type": str}}
+    assert component_outputs(comp) == {"value1": {"type": int}, "value2": {"type": str}}
 
 
 def test_outputs_dynamic_from_init():
@@ -293,4 +294,4 @@ def test_outputs_dynamic_from_init():
             return {"value": 1}
 
     comp = MockComponent()
-    assert comp._output_sockets() == {"value": {"type": int}}
+    assert component_outputs(comp) == {"value": {"type": int}}


### PR DESCRIPTION
### Why:
To enable introspection of Canals components, namely the ability to retrieve information about component inputs and outputs programmatically.

### What:
Two methods, `component_inputs` and `component_outputs`, were added in `canals/component/descriptions.py`

```
def component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
...
def component_outputs(component: Any) -> Dict[str, Dict[str, Any]]:
```

### How can it be used:
Once this PR is merged, Canals component instances could be inspected for inputs/outputs:

```python
from canals import component
from canals.component.descriptions import component_inputs, component_outputs

@component
class MockComponent:
    def run(self, value: int):
        return {"value": 1}

comp = MockComponent()
assert component_inputs(comp) == {"value": {"is_optional": False, "type": int}}



@component
class MockComponent:
    @component.output_types(value1=int, value2=str)
    def run(self):
        return {"value1": 1, "value2": "test"}

comp = MockComponent()
assert component_outputs(comp) == {"value1": {"type": int}, "value2": {"type": str}}
```

The `component_inputs` method returns a dictionary where each key is an input socket name while values are its type and optionality, and the `component_outputs` method similarly returns a dictionary mapping output socket names to their types.

### How did you test it:
Unit tests have been added to `test/component/test_component.py` to verify that the `component_inputs` and `component_outputs` methods function as expected, providing the correct details for each socket.

### Notes for reviewer:
I first added these methods to the component itself dynamically and then realized that outputs and inputs could be a field declared by the creator of the component class. This happened even in some of our test classes, causing massive test failures. I then realized it is better and safer to create class external methods - as described above. This approach is nicely symmetrical to `find_pipeline_inputs` and `find_pipeline_outputs`. 