### PR TITLE
feat: Introduce `Connection` object

### DIFF
--- a/test/pipeline/unit/test_connections.py
+++ b/test/pipeline/unit/test_connections.py
@@ -11,7 +11,7 @@ import pytest
 from canals import Pipeline
 from canals.errors import PipelineConnectError
 from canals.testing import factory
-from canals.pipeline.connections import parse_connection
+from canals.pipeline.connections import parse_connect_string
 from sample_components import AddFixedValue
 
 
@@ -411,6 +411,6 @@ def test_connect_many_connections_possible_no_name_matches():
 
 
 def test_parse_connection():
-    assert parse_connection("foobar") == ("foobar", None)
-    assert parse_connection("foo.bar") == ("foo", "bar")
-    assert parse_connection("foo.bar.baz") == ("foo", "bar.baz")
+    assert parse_connect_string("foobar") == ("foobar", None)
+    assert parse_connect_string("foo.bar") == ("foo", "bar")
+    assert parse_connect_string("foo.bar.baz") == ("foo", "bar.baz")


### PR DESCRIPTION
This PR introduces the `Connection` abstraction as a foundation for the rework of the `run()` method.

The component is a simple dataclass with 4 attributes, all optional:

- `producer_component: Optional[str]`
- `producer_socket: Optional[OutputSocket]`
- `consumer_component: Optional[str]`
- `consumer_socket: Optional[InputSocket]`

It's hashable, becuause it will be used as a dictionary key, has a repr for ease of visualization, and adds the shorthand `has_default` to make checking whether this connection includes a default value or not easier.

Connections are created by `Pipeline._direct_connect` and stored, but they're not used anywhere right now. They will be used by the refactored run() method.

Two more internal functions changed name to avoid referring to this new object indirectly:
- `parse_connection` -->  `parse_connect_string`
- `_find_unambiguous_connection` --> `_find_matching_sockets`

No tests were added at this stage because the dataclass has close to no functionality.