### PR TITLE
fix: rework the `Pipeline.run()` method

### DIFF
--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -63,8 +63,8 @@ class Pipeline:
         self.graph = networkx.MultiDiGraph()
         self._connections: List[Connection] = []
         self._mandatory_connections: Dict[str, List[Connection]] = defaultdict(list)
-        self._debug: Dict[int, Dict[str, Any]] = {}
-        self._debug_path = Path(debug_path)
+        self.debug: Dict[int, Dict[str, Any]] = {}
+        self.debug_path = Path(debug_path)
 
     def __eq__(self, other) -> bool:
         """
@@ -398,7 +398,7 @@ class Pipeline:
         data = validate_pipeline_input(self.graph, input_values=data)
         logger.info("Pipeline execution started.")
 
-        self._debug = {}
+        self.debug = {}
         if debug:
             logger.info("Debug mode ON.")
             os.makedirs("debug", exist_ok=True)
@@ -466,10 +466,10 @@ class Pipeline:
             self._record_pipeline_step(
                 step + 1, components_queue, mandatory_values_buffer, optional_values_buffer, pipeline_output
             )
-            os.makedirs(self._debug_path, exist_ok=True)
-            with open(self._debug_path / "data.json", "w", encoding="utf-8") as datafile:
-                json.dump(self._debug, datafile, indent=4, default=str)
-            pipeline_output["_debug"] = self._debug  # type: ignore
+            os.makedirs(self.debug_path, exist_ok=True)
+            with open(self.debug_path / "data.json", "w", encoding="utf-8") as datafile:
+                json.dump(self.debug, datafile, indent=4, default=str)
+            pipeline_output["_debug"] = self.debug  # type: ignore
 
         logger.info("Pipeline executed successfully.")
         return dict(pipeline_output)
@@ -481,7 +481,7 @@ class Pipeline:
         Stores a snapshot of this step into the self.debug dictionary of the pipeline.
         """
         mermaid_graph = _convert_for_debug(deepcopy(self.graph))
-        self._debug[step] = {
+        self.debug[step] = {
             "time": datetime.datetime.now(),
             "components_queue": components_queue,
             "mandatory_values_buffer": mandatory_values_buffer,

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Any, Dict, List, Literal, Union, TypeVar, Type
+from typing import Optional, Any, Dict, List, Union, TypeVar, Type, Set
 
 import os
 import json
@@ -9,7 +9,7 @@ import datetime
 import logging
 from pathlib import Path
 from copy import deepcopy
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import networkx
 
@@ -63,8 +63,8 @@ class Pipeline:
         self.graph = networkx.MultiDiGraph()
         self._connections: List[Connection] = []
         self._mandatory_connections: Dict[str, List[Connection]] = defaultdict(list)
-        self.debug: Dict[int, Dict[str, Any]] = {}
-        self.debug_path = Path(debug_path)
+        self._debug: Dict[int, Dict[str, Any]] = {}
+        self._debug_path = Path(debug_path)
 
     def __eq__(self, other) -> bool:
         """
@@ -380,13 +380,12 @@ class Pipeline:
                 logger.info("Warming up component %s...", node)
                 self.graph.nodes[node]["instance"].warm_up()
 
-    def run(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:
+    def run(self, data: Dict[str, Any], debug: bool = False) -> Dict[str, Any]:  # pylint: disable=too-many-locals
         """
         Runs the pipeline.
 
         Args:
             data: the inputs to give to the input components of the Pipeline.
-            parameters: a dictionary with all the parameters of all the components, namespaced by component.
             debug: whether to collect and return debug information.
 
         Returns:
@@ -395,124 +394,98 @@ class Pipeline:
         Raises:
             PipelineRuntimeError: if the any of the components fail or return unexpected output.
         """
-        # **** The Pipeline.run() algorithm ****
-        #
-        # Nodes are run as soon as an input for them appears in the inputs buffer.
-        # When there's more than a node at once in the buffer (which means some
-        # branches are running in parallel or that there are loops) they are selected to
-        # run in FIFO order by the `inputs_buffer` OrderedDict.
-        #
-        # Inputs are labeled with the name of the node they're aimed for:
-        #
-        #   ````
-        #   inputs_buffer[target_node] = {"input_name": input_value, ...}
-        #   ```
-        #
-        # Nodes should wait until all the necessary input data has arrived before running.
-        # If they're popped from the input_buffer before they're ready, they're put back in.
-        # If the pipeline has branches of different lengths, it's possible that a node has to
-        # wait a bit and let other nodes pass before receiving all the input data it needs.
-        #
-        # Chetsheet for networkx data access:
-        # - Name of the node       # self.graph.nodes  (List[str])
-        # - Node instance          # self.graph.nodes[node]["instance"]
-        # - Input nodes            # [e[0] for e in self.graph.in_edges(node)]
-        # - Output nodes           # [e[1] for e in self.graph.out_edges(node)]
-        # - Output edges           # [e[2]["label"] for e in self.graph.out_edges(node, data=True)]
-        #
-        # if debug:
-        #     os.makedirs("debug", exist_ok=True)
-
-        data = validate_pipeline_input(self.graph, input_values=data)
-
-        logger.info("Pipeline execution started.")
-        inputs_buffer = self._prepare_inputs_buffer(data)
-        pipeline_output: Dict[str, Dict[str, Any]] = {}
         self._clear_visits_count()
-        self.warm_up()
+        data = validate_pipeline_input(self.graph, input_values=data)
+        logger.info("Pipeline execution started.")
 
+        self._debug = {}
         if debug:
             logger.info("Debug mode ON.")
-        self.debug = {}
+            os.makedirs("debug", exist_ok=True)
+
+        logger.debug(
+            "Mandatory connections:\n%s",
+            "\n".join(
+                f" - {component}: {', '.join([str(s) for s in sockets])}"
+                for component, sockets in self._mandatory_connections.items()
+            ),
+        )
+
+        self.warm_up()
+
+        # Prepare the inputs buffer and components queue
+        components_queue: List[str] = []
+        mandatory_values_buffer: Dict[Connection, Any] = {}
+        optional_values_buffer: Dict[Connection, Any] = {}
+        pipeline_output: Dict[str, Dict[str, Any]] = defaultdict(dict)
+
+        for node_name, input_data in data.items():
+            for socket_name, value in input_data.items():
+                connection = Connection(
+                    None, None, node_name, self.graph.nodes[node_name]["input_sockets"][socket_name]
+                )
+                self._add_value_to_buffers(
+                    value, connection, components_queue, mandatory_values_buffer, optional_values_buffer
+                )
 
         # *** PIPELINE EXECUTION LOOP ***
-        # We select the nodes to run by popping them in FIFO order from the inputs buffer.
         step = 0
-        while inputs_buffer:
+        while components_queue:  # pylint: disable=too-many-nested-blocks
             step += 1
             if debug:
-                self._record_pipeline_step(step, inputs_buffer, pipeline_output)
-            logger.debug("> Queue at step %s: %s", step, {k: list(v.keys()) for k, v in inputs_buffer.items()})
+                self._record_pipeline_step(
+                    step, components_queue, mandatory_values_buffer, optional_values_buffer, pipeline_output
+                )
 
-            component_name, inputs = inputs_buffer.popitem(last=False)  # FIFO
-
-            # Make sure it didn't run too many times already
+            component_name = components_queue.pop(0)
+            logger.debug("> Queue at step %s: %s %s", step, component_name, components_queue)
             self._check_max_loops(component_name)
 
-            # **** IS IT MY TURN YET? ****
-            # Check if the component should be run or not
-            action = self._calculate_action(name=component_name, inputs=inputs, inputs_buffer=inputs_buffer)
-
-            # This component is missing data: let's put it back in the queue and wait.
-            if action == "wait":
-                if not inputs_buffer:
-                    # What if there are no components to wait for?
-                    raise PipelineRuntimeError(
-                        f"'{component_name}' is stuck waiting for input, but there are no other components to run. "
-                        "This is likely a Canals bug. Open an issue at https://github.com/deepset-ai/canals."
-                    )
-
-                inputs_buffer[component_name] = inputs
-                continue
-
-            # This component did not receive the input it needs: it must be on a skipped branch. Let's not run it.
-            if action == "skip":
-                self.graph.nodes[component_name]["visits"] += 1
-                inputs_buffer = self._skip_downstream_unvisited_nodes(
-                    component_name=component_name, inputs_buffer=inputs_buffer
-                )
-                continue
-
-            if action == "remove":
-                # This component has no reason of being in the run queue and we need to remove it. For example, this can happen to components that are connected to skipped branches of the pipeline.
-                continue
-
             # **** RUN THE NODE ****
-            # It is our turn! The node is ready to run and all necessary inputs are present
-            output = self._run_component(name=component_name, inputs=inputs)
+            if not self._ready_to_run(component_name, mandatory_values_buffer, components_queue):
+                continue
+
+            inputs = {
+                **self._extract_inputs_from_buffer(component_name, mandatory_values_buffer),
+                **self._extract_inputs_from_buffer(component_name, optional_values_buffer),
+            }
+            outputs = self._run_component(name=component_name, inputs=dict(inputs))
 
             # **** PROCESS THE OUTPUT ****
-            # The node run successfully. Let's store or distribute the output it produced, if it's valid.
-            if not self.graph.out_edges(component_name):
-                # Note: if a node outputs many times (like in loops), the output will be overwritten
-                pipeline_output[component_name] = output
-            else:
-                inputs_buffer = self._route_output(
-                    node_results=output, node_name=component_name, inputs_buffer=inputs_buffer
-                )
+            for socket_name, value in outputs.items():
+                targets = self._collect_targets(component_name, socket_name)
+                if not targets:
+                    pipeline_output[component_name][socket_name] = value
+                else:
+                    for target in targets:
+                        self._add_value_to_buffers(
+                            value, target, components_queue, mandatory_values_buffer, optional_values_buffer
+                        )
 
         if debug:
-            self._record_pipeline_step(step + 1, inputs_buffer, pipeline_output)
-
-            # Save to json
-            os.makedirs(self.debug_path, exist_ok=True)
-            with open(self.debug_path / "data.json", "w", encoding="utf-8") as datafile:
-                json.dump(self.debug, datafile, indent=4, default=str)
-
-            # Store in the output
-            pipeline_output["_debug"] = self.debug  # type: ignore
+            self._record_pipeline_step(
+                step + 1, components_queue, mandatory_values_buffer, optional_values_buffer, pipeline_output
+            )
+            os.makedirs(self._debug_path, exist_ok=True)
+            with open(self._debug_path / "data.json", "w", encoding="utf-8") as datafile:
+                json.dump(self._debug, datafile, indent=4, default=str)
+            pipeline_output["_debug"] = self._debug  # type: ignore
 
         logger.info("Pipeline executed successfully.")
-        return pipeline_output
+        return dict(pipeline_output)
 
-    def _record_pipeline_step(self, step, inputs_buffer, pipeline_output):
+    def _record_pipeline_step(
+        self, step, components_queue, mandatory_values_buffer, optional_values_buffer, pipeline_output
+    ):
         """
         Stores a snapshot of this step into the self.debug dictionary of the pipeline.
         """
         mermaid_graph = _convert_for_debug(deepcopy(self.graph))
-        self.debug[step] = {
+        self._debug[step] = {
             "time": datetime.datetime.now(),
-            "inputs_buffer": list(inputs_buffer.items()),
+            "components_queue": components_queue,
+            "mandatory_values_buffer": mandatory_values_buffer,
+            "optional_values_buffer": optional_values_buffer,
             "pipeline_output": pipeline_output,
             "diagram": mermaid_graph,
         }
@@ -533,188 +506,83 @@ class Pipeline:
                 f"Maximum loops count ({self.max_loops_allowed}) exceeded for component '{component_name}'."
             )
 
-    # This function is complex so it contains quite some logic, it needs tons of information
-    # regarding a component to understand what action it should take so we have many local
-    # variables and to keep things simple we also have multiple returns.
-    # In the end this amount of information makes it easier to understand the internal logic so
-    # we chose to ignore these pylint warnings.
-    def _calculate_action(  # pylint: disable=too-many-locals, too-many-return-statements
-        self, name: str, inputs: Dict[str, Any], inputs_buffer: Dict[str, Any]
-    ) -> Literal["run", "wait", "skip", "remove"]:
+    def _add_value_to_buffers(
+        self,
+        value: Any,
+        connection: Connection,
+        components_queue: List[str],
+        mandatory_values_buffer: Dict[Connection, Any],
+        optional_values_buffer: Dict[Connection, Any],
+    ):
         """
-        Calculates the action to take for the component specified by `name`.
-        There are four possible actions:
-            * run
-            * wait
-            * skip
-            * remove
-
-        The below conditions are evaluated in this order.
-
-        Component will run if at least one of the following statements is true:
-            * It received all mandatory inputs
-            * It received all mandatory inputs and it has no optional inputs
-            * It received all mandatory inputs and all optional inputs are skipped
-            * It received all mandatory inputs and some optional inputs and the rest are skipped
-            * It received some of its inputs and the others are defaulted
-            * It's the first component of the pipeline
-
-        Component will wait if:
-            * It received some of its inputs and the other are not skipped
-            * It received all mandatory inputs and some optional inputs have not been skipped
-
-        Component will be skipped if:
-            * It never ran nor waited
-
-        Component will be removed if:
-            * It ran or waited at least once but can't do it again
-
-        If none of the above condition is met a PipelineRuntimeError is raised.
-
-        For simplicity sake input components that create a cycle, or components that already ran
-        and don't create a cycle are considered as skipped.
-
-        Args:
-            name: Name of the component
-            inputs: Values that the component will take as input
-            inputs_buffer: Other components' inputs
-
-        Returns:
-            Action to take for component specifing whether it should run, wait, skip or be removed
-
-        Raises:
-            PipelineRuntimeError: If action to take can't be determined
+        Given a value and the connection it is being sent on, it updates the buffers and the components queue.
         """
+        if not connection.has_default():
+            mandatory_values_buffer[connection] = value
+            if connection.consumer_component and connection.consumer_component not in components_queue:
+                components_queue.append(connection.consumer_component)
+        else:
+            optional_values_buffer[connection] = value
 
-        # Upstream components/socket pairs the current component is connected to
-        input_components = {
-            from_node: data["to_socket"].name for from_node, _, data in self.graph.in_edges(name, data=True)
-        }
-        # Sockets that have received inputs from upstream components
-        received_input_sockets = set(inputs.keys())
-
-        # All components inputs, whether they're connected, default or pipeline inputs
-        input_sockets: Dict[str, InputSocket] = self.graph.nodes[name]["input_sockets"].keys()
-        optional_input_sockets = {
-            socket.name for socket in self.graph.nodes[name]["input_sockets"].values() if not socket.has_default
-        }
-        mandatory_input_sockets = {
-            socket.name for socket in self.graph.nodes[name]["input_sockets"].values() if socket.has_default
-        }
-
-        # Components that are in the inputs buffer and have no inputs assigned are considered skipped
-        skipped_components = {n for n, v in inputs_buffer.items() if not v}
-
-        # Sockets that have their upstream component marked as skipped
-        skipped_optional_input_sockets = {
-            sockets["to_socket"].name
-            for from_node, _, sockets in self.graph.in_edges(name, data=True)
-            if from_node in skipped_components and sockets["to_socket"].name in optional_input_sockets
-        }
-
-        for from_node, socket in input_components.items():
-            if socket not in optional_input_sockets:
-                continue
-            loops_back = networkx.has_path(self.graph, name, from_node)
-            has_run = self.graph.nodes[from_node]["visits"] > 0
-            if loops_back or has_run:
-                # Consider all input components that loop back to current component
-                # or that have already run at least once as skipped.
-                # This must be done to correctly handle cycles in the pipeline or we
-                # would reach a dead lock in components that have multiple inputs and
-                # one of these forms a cycle.
-                skipped_optional_input_sockets.add(socket)
-
-        ##############
-        # RUN CHECKS #
-        ##############
-        if (
-            mandatory_input_sockets.issubset(received_input_sockets)
-            and input_sockets == received_input_sockets | mandatory_input_sockets | skipped_optional_input_sockets
-        ):
-            # We received all mandatory inputs and:
-            #   * There are no optional inputs or
-            #   * All optional inputs are skipped or
-            #   * We received part of the optional inputs, the rest are skipped
-            if not optional_input_sockets:
-                logger.debug("Component '%s' is ready to run. All mandatory inputs received.", name)
-            else:
-                logger.debug(
-                    "Component '%s' is ready to run. All mandatory inputs received, skipped optional inputs: %s",
-                    name,
-                    skipped_optional_input_sockets,
-                )
-            return "run"
-
-        if set(input_components.values()).issubset(received_input_sockets):
-            # We have data from each connected input component.
-            # We reach this when the current component is the first of the pipeline or
-            # when it has defaults and all its input components have run.
-            logger.debug("Component '%s' is ready to run. All expected inputs were received.", name)
-            return "run"
-
-        ###############
-        # WAIT CHECKS #
-        ###############
-        if mandatory_input_sockets == received_input_sockets and skipped_optional_input_sockets.issubset(
-            optional_input_sockets
-        ):
-            # We received all of the inputs we need, but some optional inputs have not been run or skipped yet
-            logger.debug(
-                "Component '%s' is waiting. All mandatory inputs received, some optional are not skipped: %s",
-                name,
-                optional_input_sockets - skipped_optional_input_sockets,
-            )
-            return "wait"
-
-        if any(self.graph.nodes[n]["visits"] == 0 for n in input_components.keys()):
-            # Some upstream component that must send input to the current component has yet to run.
-            logger.debug("Component '%s' is waiting. Missing inputs: %s", name, set(input_components.values()))
-            return "wait"
-
-        ###############
-        # SKIP CHECKS #
-        ###############
-        if self.graph.nodes[name]["visits"] == 0:
-            # It's the first time visiting this component, if it can't run nor wait
-            # it's fine skipping it at this point.
-            logger.debug("Component '%s' is skipped. It can't run nor wait.", name)
-            return "skip"
-
-        #################
-        # REMOVE CHECKS #
-        #################
-        if self.graph.nodes[name]["visits"] > 0:
-            # This component has already been visited at least once. If it can't run nor wait
-            # there is no reason to skip it again. So we it must be removed.
-            logger.debug("Component '%s' is removed. It can't run, wait or skip.", name)
-            return "remove"
-
-        # Can't determine action to take
-        raise PipelineRuntimeError(
-            f"Can't determine Component '{name}' action. "
-            f"Mandatory input sockets: {mandatory_input_sockets}, "
-            f"optional input sockets: {optional_input_sockets}, "
-            f"received input: {list(inputs.keys())}, "
-            f"input components: {list(input_components.keys())}, "
-            f"skipped components: {skipped_components}, "
-            f"skipped optional inputs: {skipped_optional_input_sockets}."
-            f"This is likely a Canals bug. Please open an issue at https://github.com/deepset-ai/canals."
+    def _ready_to_run(
+        self, component_name: str, mandatory_values_buffer: Dict[Connection, Any], components_queue: List[str]
+    ) -> bool:
+        """
+        Returns True if a component is ready to run, False otherwise.
+        """
+        received_connections = set(
+            conn for conn in mandatory_values_buffer.keys() if conn.consumer_component == component_name
         )
+        expected_connections = set(self._mandatory_connections[component_name])
+        if expected_connections.issubset(received_connections):
+            logger.debug("Component '%s' is ready to run. All mandatory values were received.", component_name)
+            return True
 
-    def _skip_downstream_unvisited_nodes(self, component_name: str, inputs_buffer: OrderedDict) -> OrderedDict:
+        # Check whether the missing values are still being computed
+        missing_connections: Set[Connection] = expected_connections - received_connections
+        connections_to_wait = []
+        for missing_conn in missing_connections:
+            if any(
+                networkx.has_path(self.graph, component_to_run, missing_conn.producer_component)
+                for component_to_run in components_queue
+            ):
+                connections_to_wait.append(missing_conn)
+        if not connections_to_wait:
+            # Just run the component: missing sockets will never arrive
+            logger.debug(
+                "Component '%s' is ready to run. A variadic input parameter received all the expected values.",
+                component_name,
+            )
+            return True
+
+        # Wait for the values
+        logger.debug(
+            "Component '%s' is not ready to run, some values are still missing: %s",
+            component_name,
+            connections_to_wait,
+        )
+        components_queue.append(component_name)
+        return False
+
+    def _extract_inputs_from_buffer(self, component_name: str, buffer: Dict[Connection, Any]) -> Dict[str, Any]:
         """
-        When a component is skipped, put all downstream nodes in the inputs buffer too: the might be skipped too,
-        unless they are merge nodes. They will be evaluated later by the pipeline execution loop.
+        Extract a component's input values from one of the value buffers.
         """
-        downstream_nodes = [e[1] for e in self.graph.out_edges(component_name)]
-        for downstream_node in downstream_nodes:
-            if downstream_node in inputs_buffer:
-                continue
-            if self.graph.nodes[downstream_node]["visits"] == 0:
-                # Skip downstream nodes only if they never been visited
-                inputs_buffer[downstream_node] = {}
-        return inputs_buffer
+        inputs = defaultdict(list)
+        connections: List[Connection] = []
+
+        for connection in buffer.keys():
+            if connection.consumer_component == component_name:
+                connections.append(connection)
+
+        for key in connections:
+            value = buffer.pop(key)
+            if key.consumer_socket:
+                if key.consumer_socket.is_variadic:
+                    inputs[key.consumer_socket.name].append(value)
+                else:
+                    inputs[key.consumer_socket.name] = value
+        return inputs
 
     def _run_component(self, name: str, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -723,7 +591,7 @@ class Pipeline:
         self.graph.nodes[name]["visits"] += 1
         instance = self.graph.nodes[name]["instance"]
         try:
-            logger.info("* Running %s (visits: %s)", name, self.graph.nodes[name]["visits"])
+            logger.info("* Running %s", name)
             logger.debug("   '%s' inputs: %s", name, inputs)
 
             outputs = instance.run(**inputs)
@@ -734,8 +602,7 @@ class Pipeline:
             # Make sure the component returned a dictionary
             if not isinstance(outputs, dict):
                 raise PipelineRuntimeError(
-                    f"Component '{name}' returned a value of type "
-                    f"'{getattr(type(outputs), '__name__', str(type(outputs)))}' instead of a dict. "
+                    f"Component '{name}' returned a value of type '{_type_name(type(outputs))}' instead of a dict. "
                     "Components must always return dictionaries: check the the documentation."
                 )
 
@@ -747,63 +614,15 @@ class Pipeline:
 
         return outputs
 
-    def _route_output(self, node_name: str, node_results: Dict[str, Any], inputs_buffer: OrderedDict) -> OrderedDict:
+    def _collect_targets(self, component_name: str, socket_name: str) -> List[Connection]:
         """
-        Distrubute the outputs of the component into the input buffer of downstream components.
-
-        Returns the updated inputs buffer.
+        Given and component and an output socket names, returns a list of Connections
+        where these are the producers. Used to route output.
         """
-        # This is not a terminal node: find out where the output goes, to which nodes and along which edge
-        is_decision_node_for_loop = (
-            any(networkx.has_path(self.graph, edge[1], node_name) for edge in self.graph.out_edges(node_name))
-            and len(self.graph.out_edges(node_name)) > 1
-        )
-        for edge_data in self.graph.out_edges(node_name, data=True):
-            to_socket = edge_data[2]["to_socket"]
-            from_socket = edge_data[2]["from_socket"]
-            target_node = edge_data[1]
-
-            # If this is a decision node and a loop is involved, we add to the input buffer only the nodes
-            # that received their expected output and we leave the others out of the queue.
-            if is_decision_node_for_loop and node_results.get(from_socket.name, None) is None:
-                if networkx.has_path(self.graph, target_node, node_name):
-                    # In case we're choosing to leave a loop, do not put the loop's node in the buffer.
-                    logger.debug("Not adding '%s' to the inputs buffer: we're leaving the loop.", target_node)
-                else:
-                    # In case we're choosing to stay in a loop, do not put the external node in the buffer.
-                    logger.debug("Not adding '%s' to the inputs buffer: we're staying in the loop.", target_node)
-            else:
-                # In all other cases, populate the inputs buffer for all downstream nodes.
-
-                # Create the buffer for the downstream node if it's not yet there.
-                if target_node not in inputs_buffer:
-                    inputs_buffer[target_node] = {}
-
-                # Skip Edges that did not receive any input.
-                value_to_route = node_results.get(from_socket.name)
-                if value_to_route is None:
-                    continue
-
-                # If the socket was marked as variadic, pile up inputs in a list
-                if to_socket.is_variadic:
-                    inputs_buffer[target_node].setdefault(to_socket.name, []).append(value_to_route)
-                # Non-variadic input: just store the value
-                else:
-                    inputs_buffer[target_node][to_socket.name] = value_to_route
-
-        return inputs_buffer
-
-    def _prepare_inputs_buffer(self, data: Dict[str, Any]) -> OrderedDict:
-        """
-        Prepare the inputs buffer based on the parameters that were
-        passed to run()
-        """
-        inputs_buffer: OrderedDict = OrderedDict()
-        for node_name, input_data in data.items():
-            for socket_name, value in input_data.items():
-                if value is None:
-                    continue
-                if self.graph.nodes[node_name]["input_sockets"][socket_name].is_variadic:
-                    value = [value]
-                inputs_buffer.setdefault(node_name, {})[socket_name] = value
-        return inputs_buffer
+        return [
+            connection
+            for connection in self._connections
+            if connection.producer_component == component_name
+            and connection.producer_socket
+            and connection.producer_socket.name == socket_name
+        ]

--- a/sample_components/merge_loop.py
+++ b/sample_components/merge_loop.py
@@ -69,4 +69,4 @@ class MergeLoop:
         for value in kwargs.values():
             if value is not None:
                 return {"value": value}
-        return {"value": None}
+        return {}

--- a/sample_components/parity.py
+++ b/sample_components/parity.py
@@ -17,5 +17,5 @@ class Parity:  # pylint: disable=too-few-public-methods
         """
         remainder = value % 2
         if remainder:
-            return {"even": None, "odd": value}
-        return {"even": value, "odd": None}
+            return {"odd": value}
+        return {"even": value}

--- a/sample_components/remainder.py
+++ b/sample_components/remainder.py
@@ -17,5 +17,5 @@ class Remainder:
         :param value: the value to check the remainder of.
         """
         remainder = value % self.divisor
-        output = {f"remainder_is_{val}": None if val != remainder else value for val in range(self.divisor)}
+        output = {f"remainder_is_{remainder}": value}
         return output

--- a/sample_components/threshold.py
+++ b/sample_components/threshold.py
@@ -33,5 +33,5 @@ class Threshold:  # pylint: disable=too-few-public-methods
             threshold = self.threshold
 
         if value < threshold:
-            return {"above": None, "below": value}
-        return {"above": value, "below": None}
+            return {"below": value}
+        return {"above": value}

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -120,7 +120,7 @@ def test_merge_second():
 def test_merge_nones():
     component = MergeLoop(expected_type=int, inputs=["in_1", "in_2", "in_3"])
     results = component.run()
-    assert results == {"value": None}
+    assert results == {}
 
 
 def test_merge_one():
@@ -132,4 +132,4 @@ def test_merge_one():
 def test_merge_one_none():
     component = MergeLoop(expected_type=int, inputs=[])
     results = component.run()
-    assert results == {"value": None}
+    assert results == {}

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -20,6 +20,6 @@ def test_from_dict():
 def test_parity():
     component = Parity()
     results = component.run(value=1)
-    assert results == {"odd": 1, "even": None}
+    assert results == {"odd": 1}
     results = component.run(value=2)
-    assert results == {"odd": None, "even": 2}
+    assert results == {"even": 2}

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -34,13 +34,13 @@ def test_from_dict_with_custom_divisor_value():
 def test_remainder_default():
     component = Remainder()
     results = component.run(value=4)
-    assert results == {"remainder_is_0": None, "remainder_is_1": 4, "remainder_is_2": None}
+    assert results == {"remainder_is_1": 4}
 
 
 def test_remainder_with_divisor():
     component = Remainder(divisor=4)
     results = component.run(value=4)
-    assert results == {"remainder_is_0": 4, "remainder_is_1": None, "remainder_is_2": None, "remainder_is_3": None}
+    assert results == {"remainder_is_0": 4}
 
 
 def test_remainder_zero():

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -33,7 +33,7 @@ def test_threshold():
     component = Threshold()
 
     results = component.run(value=5, threshold=10)
-    assert results == {"above": None, "below": 5}
+    assert results == {"below": 5}
 
     results = component.run(value=15, threshold=10)
-    assert results == {"above": 15, "below": None}
+    assert results == {"above": 15}


### PR DESCRIPTION
This PR is a rework of the `run()` method.

The `inputs_buffer` object has been split into three separate data structures:

- `components_queue: List[str]`: contains the list of the components to process, similar to the old inputs_buffer.keys()

- `mandatory_values_buffer: Dict[Connection, Any]`: For each connection that exists in the pipeline where the receiving socket is mandatory, it stores the value that is being sent over that connection. Uses Connection objects as keys to ease access.
- `optional_values_buffer: Dict[Connection, Any]`: Identical to `mandatory_values_buffer`, but for connections that are not mandatory.

Due to this change, the possible actions for a component have been reduced from four (`run`, `wait`, `skip`, `remove`) to a boolean value where `True == "run"` and `False == "wait"`. Now skipping branches is done by not adding a given component to the `components_queue` instead of signaling the skip with a `None`. 

Skipped branches are detected as follows: if from no component in the components queue, `networkx.has_path(component, waiting_component)`is True, then the connection will never receive a value and therefore it is not waited for.

This PR fixes all the failing tests introduced by https://github.com/deepset-ai/canals/pull/154 and following PRs.