### PR TITLE
feat: Fix find_component_inputs, update unit tests

### DIFF
--- a/canals/component/descriptions.py
+++ b/canals/component/descriptions.py
@@ -18,7 +18,7 @@ def find_component_inputs(component: Any) -> Dict[str, Dict[str, Any]]:
         )
 
     return {
-        name: {"type": socket.type, "is_optional": socket.is_optional}
+        name: {"type": socket.type, "is_mandatory": socket.is_mandatory, "is_variadic": socket.is_variadic}
         for name, socket in component.__canals_input__.items()
     }
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -184,7 +184,7 @@ def test_inputs_method_one_input():
             return {"value": 1}
 
     comp = MockComponent()
-    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
+    assert find_component_inputs(comp) == {"value": {"is_mandatory": True, "is_variadic": False, "type": int}}
 
 
 def test_inputs_method_multiple_inputs():
@@ -195,8 +195,8 @@ def test_inputs_method_multiple_inputs():
 
     comp = MockComponent()
     assert find_component_inputs(comp) == {
-        "value1": {"is_optional": False, "type": int},
-        "value2": {"is_optional": False, "type": str},
+        "value1": {"is_mandatory": True, "is_variadic": False, "type": int},
+        "value2": {"is_mandatory": True, "is_variadic": False, "type": str},
     }
 
 
@@ -208,8 +208,8 @@ def test_inputs_method_multiple_inputs_optional():
 
     comp = MockComponent()
     assert find_component_inputs(comp) == {
-        "value1": {"is_optional": False, "type": int},
-        "value2": {"is_optional": True, "type": typing.Optional[str]},
+        "value1": {"is_mandatory": True, "is_variadic": False, "type": int},
+        "value2": {"is_mandatory": True, "is_variadic": False, "type": typing.Optional[str]},
     }
 
 
@@ -223,7 +223,7 @@ def test_inputs_method_variadic_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
+    assert find_component_inputs(comp) == {"value": {"is_mandatory": True, "is_variadic": False, "type": typing.Any}}
 
 
 def test_inputs_method_variadic_keyword_positional_args():
@@ -236,7 +236,7 @@ def test_inputs_method_variadic_keyword_positional_args():
             return {"value": 1}
 
     comp = MockComponent()
-    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": typing.Any}}
+    assert find_component_inputs(comp) == {"value": {"is_mandatory": True, "is_variadic": False, "type": typing.Any}}
 
 
 def test_inputs_dynamic_from_init():
@@ -249,7 +249,7 @@ def test_inputs_dynamic_from_init():
             return {"value": 1}
 
     comp = MockComponent()
-    assert find_component_inputs(comp) == {"value": {"is_optional": False, "type": int}}
+    assert find_component_inputs(comp) == {"value": {"is_mandatory": True, "is_variadic": False, "type": int}}
 
 
 def test_outputs_method_no_outputs():


### PR DESCRIPTION
- Fixes premature merge of https://github.com/deepset-ai/canals/pull/158 
- I didn't update the branch and rerun unit tests before the merge
- is_optional field was removed from the canals input socket, causing execution and test failures
- This PR fixes `find_component_inputs` to report on `is_mandatory` and `is_variadic` fields of an input socket