### PR TITLE
feat: read defaults from `run()` signature

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -185,6 +185,28 @@ class _Component:
             def run(self, **kwargs):
                 return {"output_1": kwargs["value_1"], "output_2": ""}
         ```
+
+        Note that if the `run()` method also specifies some parameters, those will take precedence.
+
+        For example:
+
+        ```python
+        @component
+        class MyComponent:
+
+            def __init__(self, value: int):
+                component.set_input_types(value_1=str, value_2=str)
+                ...
+
+            @component.output_types(output_1=int, output_2=str)
+            def run(self, value_0: str, value_1: Optional[str] = None, **kwargs):
+                return {"output_1": kwargs["value_1"], "output_2": ""}
+        ```
+
+        would add a mandatory `value_0` parameters, make the `value_1`
+        parameter optional with a default None, and keep the `value_2`
+        parameter mandatory as specified in `set_input_types`.
+
         """
         instance.__canals_input__ = {name: InputSocket(name=name, type=type_) for name, type_ in types.items()}
 

--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -133,31 +133,17 @@ class ComponentMeta(type):
             # to the actual instance, so that different instances of the same class won't share this data.
             instance.__canals_output__ = deepcopy(getattr(instance.run, "_output_types_cache", {}))
 
-        # If the __init__ called component.set_input_types(), __canals_input__ is already populated
-        # and we only need to check for defaults
+        # Create the sockets if set_input_types() wasn't called in the constructor.
+        # If it was called and there are some parameters also in the `run()` method, these take precedence.
+        if not hasattr(instance, "__canals_input__"):
+            instance.__canals_input__ = {}
         run_signature = inspect.signature(getattr(cls, "run"))
-        if hasattr(instance, "__canals_input__"):
-            for param in list(run_signature.parameters)[1:]:  # First is 'self' and it doesn't matter.
-                if run_signature.parameters[param].default != inspect.Parameter.empty:
-                    if param not in instance.__canals_input__:
-                        instance.__canals_input__[param] = InputSocket(
-                            name=param,
-                            type=run_signature.parameters[param].annotation,
-                            is_mandatory=run_signature.parameters[param].default == inspect.Parameter.empty,
-                        )
-                    else:
-                        instance.__canals_input__[param].is_mandatory = False
-        else:
-            # Otherwise, create the input sockets
-            instance.__canals_input__ = {
-                param: InputSocket(
-                    name=param,
-                    type=run_signature.parameters[param].annotation,
-                    is_mandatory=run_signature.parameters[param].default == inspect.Parameter.empty,
-                )
-                for param in list(run_signature.parameters)[1:]  # First is 'self' and it doesn't matter.
-            }
-
+        for param in list(run_signature.parameters)[1:]:  # First is 'self' and it doesn't matter.
+            instance.__canals_input__[param] = InputSocket(
+                name=param,
+                type=run_signature.parameters[param].annotation,
+                is_mandatory=run_signature.parameters[param].default == inspect.Parameter.empty,
+            )
         return instance
 
 

--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -139,11 +139,12 @@ class ComponentMeta(type):
             instance.__canals_input__ = {}
         run_signature = inspect.signature(getattr(cls, "run"))
         for param in list(run_signature.parameters)[1:]:  # First is 'self' and it doesn't matter.
-            instance.__canals_input__[param] = InputSocket(
-                name=param,
-                type=run_signature.parameters[param].annotation,
-                is_mandatory=run_signature.parameters[param].default == inspect.Parameter.empty,
-            )
+            if run_signature.parameters[param].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:  # ignore kwargs
+                instance.__canals_input__[param] = InputSocket(
+                    name=param,
+                    type=run_signature.parameters[param].annotation,
+                    is_mandatory=run_signature.parameters[param].default == inspect.Parameter.empty,
+                )
         return instance
 
 

--- a/sample_components/__init__.py
+++ b/sample_components/__init__.py
@@ -17,6 +17,7 @@ from sample_components.hello import Hello
 from sample_components.text_splitter import TextSplitter
 from sample_components.merge_loop import MergeLoop
 from sample_components.self_loop import SelfLoop
+from sample_components.fstring import FString
 
 __all__ = [
     "Concatenate",
@@ -37,4 +38,5 @@ __all__ = [
     "StringListJoiner",
     "FirstIntSelector",
     "SelfLoop",
+    "FString",
 ]

--- a/sample_components/fstring.py
+++ b/sample_components/fstring.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2022-present deepset GmbH <info@deepset.ai>
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import List, Any, Optional
+
+from canals import component
+
+
+@component
+class FString:
+    """
+    Takes a template string and a list of variables in input and returns the formatted string in output.
+    """
+
+    def __init__(self, template: str, variables: Optional[List[str]] = None):
+        self.template = template
+        self.variables = variables or []
+        if any(variable == "template" for variable in self.variables):
+            raise ValueError("The variable name 'template' is reserved and cannot be used.")
+        component.set_input_types(self, **{variable: Any for variable in self.variables})
+
+    @component.output_types(string=str)
+    def run(self, template: Optional[str] = None, **kwargs):
+        """
+        Takes a template string and a list of variables in input and returns the formatted string in output.
+
+        If the template is not given, the component will use the one given at initialization.
+        """
+        if not template:
+            template = self.template
+        return {"string": template.format(**kwargs)}

--- a/test/pipeline/integration/test_dynamic_inputs_pipeline.py
+++ b/test/pipeline/integration/test_dynamic_inputs_pipeline.py
@@ -1,0 +1,23 @@
+from canals import Pipeline
+from sample_components import FString, Hello, TextSplitter
+
+
+def test_pipeline():
+    pipeline = Pipeline()
+    pipeline.add_component("hello", Hello())
+    pipeline.add_component("fstring", FString(template="This is the greeting: {greeting}!", variables=["greeting"]))
+    pipeline.add_component("splitter", TextSplitter())
+    pipeline.connect("hello.output", "fstring.greeting")
+    pipeline.connect("fstring.string", "splitter.sentence")
+
+    pipeline.draw("dynamic_inputs_pipeline.png")
+
+    output = pipeline.run({"hello": {"word": "Alice"}})
+    assert output == {"splitter": {"output": ["This", "is", "the", "greeting:", "Hello,", "Alice!!"]}}
+
+    output = pipeline.run({"hello": {"word": "Alice"}, "fstring": {"template": "Received: {greeting}"}})
+    assert output == {"splitter": {"output": ["Received:", "Hello,", "Alice!"]}}
+
+
+if __name__ == "__main__":
+    test_pipeline()

--- a/test/pipeline/integration/test_dynamic_inputs_pipeline.py
+++ b/test/pipeline/integration/test_dynamic_inputs_pipeline.py
@@ -1,8 +1,9 @@
+from pathlib import Path
 from canals import Pipeline
 from sample_components import FString, Hello, TextSplitter
 
 
-def test_pipeline():
+def test_pipeline(tmp_path):
     pipeline = Pipeline()
     pipeline.add_component("hello", Hello())
     pipeline.add_component("fstring", FString(template="This is the greeting: {greeting}!", variables=["greeting"]))
@@ -10,7 +11,7 @@ def test_pipeline():
     pipeline.connect("hello.output", "fstring.greeting")
     pipeline.connect("fstring.string", "splitter.sentence")
 
-    pipeline.draw("dynamic_inputs_pipeline.png")
+    pipeline.draw(tmp_path / "dynamic_inputs_pipeline.png")
 
     output = pipeline.run({"hello": {"word": "Alice"}})
     assert output == {"splitter": {"output": ["This", "is", "the", "greeting:", "Hello,", "Alice!!"]}}
@@ -20,4 +21,4 @@ def test_pipeline():
 
 
 if __name__ == "__main__":
-    test_pipeline()
+    test_pipeline(Path(__file__).parent)

--- a/test/sample_components/test_fstring.py
+++ b/test/sample_components/test_fstring.py
@@ -1,0 +1,38 @@
+import pytest
+from sample_components import FString
+
+
+def test_fstring_with_one_var():
+    fstring = FString(template="Hello, {name}!", variables=["name"])
+    output = fstring.run(name="Alice")
+    assert output == {"string": "Hello, Alice!"}
+
+
+def test_fstring_with_no_vars():
+    fstring = FString(template="No variables in this template.", variables=[])
+    output = fstring.run()
+    assert output == {"string": "No variables in this template."}
+
+
+def test_fstring_with_template_at_runtime():
+    fstring = FString(template="Hello {name}", variables=["name"])
+    output = fstring.run(template="Goodbye {name}!", name="Alice")
+    assert output == {"string": "Goodbye Alice!"}
+
+
+def test_fstring_with_vars_mismatch():
+    fstring = FString(template="Hello {name}", variables=["name"])
+    with pytest.raises(KeyError):
+        fstring.run(template="Goodbye {person}!", name="Alice")
+
+
+def test_fstring_with_vars_in_excess():
+    fstring = FString(template="Hello {name}", variables=["name"])
+    output = fstring.run(template="Goodbye!", name="Alice")
+    assert output == {"string": "Goodbye!"}
+
+
+def test_fstring_with_vars_missing():
+    fstring = FString(template="{greeting}, {name}!", variables=["name"])
+    with pytest.raises(KeyError):
+        fstring.run(greeting="Hello")


### PR DESCRIPTION
Follow up of https://github.com/deepset-ai/canals/pull/148

---

Currently,  input sockets are read from the `set_input_types` call only, and therefore all count as mandatory. However, one may want to still specify defaults for non-dynamic inputs, such as what PromptBuilder does now:

```python
class PromptBuilder:

    def __init__(self, ...):
        ....
        component.set_input_types(self, **dynamic_input_slots)

    def run(self, messages: Optional[List[ChatMessage]] = None, **kwargs): 
        ...
```

This PR makes the signature above work by reading the signature of `run()` even when `__canals_inputs__` already exists, and makes sure to add additional sockets and to check whether they have defaults.

It also adds a sample component showing this signature (`FString`, similar to `PromptBuilder`), unit tests for it,  and a small integration test with a Pipeline using such component.