### PR TITLE
Use full import path as 'type' in serialization. 

### DIFF
--- a/canals/component/component.py
+++ b/canals/component/component.py
@@ -265,15 +265,16 @@ class _Component:
         class_ = new_class(class_.__name__, class_.__bases__, {"metaclass": ComponentMeta}, copy_class_namespace)
 
         # Save the component in the class registry (for deserialization)
-        if class_.__name__ in self.registry:
+        class_path = f"{class_.__module__}.{class_.__name__}"
+        if class_path in self.registry:
             # Corner case, but it may occur easily in notebooks when re-running cells.
             logger.debug(
                 "Component %s is already registered. Previous imported from '%s', new imported from '%s'",
-                class_.__name__,
-                self.registry[class_.__name__],
+                class_path,
+                self.registry[class_path],
                 class_,
             )
-        self.registry[class_.__name__] = class_
+        self.registry[class_path] = class_
         logger.debug("Registered Component %s", class_)
 
         return class_

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -158,6 +158,7 @@ class Pipeline:
                     try:
                         # Import the module first...
                         module, _ = component_data["type"].rsplit(".", 1)
+                        logger.debug("Trying to import %s", module)
                         importlib.import_module(module)
                         # ...then try again
                         if component_data["type"] not in component.registry:

--- a/canals/pipeline/pipeline.py
+++ b/canals/pipeline/pipeline.py
@@ -162,7 +162,10 @@ class Pipeline:
                         importlib.import_module(module)
                         # ...then try again
                         if component_data["type"] not in component.registry:
-                            raise PipelineError()
+                            raise PipelineError(
+                                f"Successfully imported module {module} but can't find it in the component registry."
+                                "This is unexpected and most likely a bug."
+                            )
                     except (ImportError, PipelineError) as e:
                         raise PipelineError(f"Component '{component_data['type']}' not imported.") from e
 

--- a/canals/serialization.py
+++ b/canals/serialization.py
@@ -82,7 +82,7 @@ def default_to_dict(obj: Any, **init_parameters) -> Dict[str, Any]:
     ```
     """
     return {
-        "type": obj.__class__.__name__,
+        "type": f"{obj.__class__.__module__}.{obj.__class__.__name__}",
         "init_parameters": init_parameters,
     }
 
@@ -101,6 +101,6 @@ def default_from_dict(cls: Type[object], data: Dict[str, Any]) -> Any:
     init_params = data.get("init_parameters", {})
     if "type" not in data:
         raise DeserializationError("Missing 'type' in serialization data")
-    if data["type"] != cls.__name__:
+    if data["type"] != f"{cls.__module__}.{cls.__name__}":
         raise DeserializationError(f"Class '{data['type']}' can't be deserialized as '{cls.__name__}'")
     return cls(**init_params)

--- a/sample_components/accumulate.py
+++ b/sample_components/accumulate.py
@@ -51,8 +51,8 @@ class Accumulate:
     def from_dict(cls, data: Dict[str, Any]) -> "Accumulate":  # pylint: disable=missing-function-docstring
         if "type" not in data:
             raise ComponentDeserializationError("Missing 'type' in component serialization data")
-        if data["type"] != cls.__name__:
-            raise ComponentDeserializationError(f"Component '{data['type']}' can't be deserialized as '{cls.__name__}'")
+        if data["type"] != f"{cls.__module__}.{cls.__name__}":
+            raise ComponentDeserializationError(f"Class '{data['type']}' can't be deserialized as '{cls.__name__}'")
 
         init_params = data.get("init_parameters", {})
 

--- a/sample_components/merge_loop.py
+++ b/sample_components/merge_loop.py
@@ -35,8 +35,8 @@ class MergeLoop:
     def from_dict(cls, data: Dict[str, Any]) -> "MergeLoop":  # pylint: disable=missing-function-docstring
         if "type" not in data:
             raise DeserializationError("Missing 'type' in component serialization data")
-        if data["type"] != cls.__name__:
-            raise DeserializationError(f"Component '{data['type']}' can't be deserialized as '{cls.__name__}'")
+        if data["type"] != f"{cls.__module__}.{cls.__name__}":
+            raise DeserializationError(f"Class '{data['type']}' can't be deserialized as '{cls.__name__}'")
 
         init_params = data.get("init_parameters", {})
 

--- a/test/component/test_component.py
+++ b/test/component/test_component.py
@@ -25,7 +25,7 @@ def test_correct_declaration():
 
     # Verifies also instantiation works with no issues
     assert MockComponent()
-    assert component.registry["MockComponent"] == MockComponent
+    assert component.registry["test_component.MockComponent"] == MockComponent
 
 
 def test_correct_declaration_with_additional_readonly_property():
@@ -48,7 +48,7 @@ def test_correct_declaration_with_additional_readonly_property():
 
     # Verifies that instantiation works with no issues
     assert MockComponent()
-    assert component.registry["MockComponent"] == MockComponent
+    assert component.registry["test_component.MockComponent"] == MockComponent
     assert MockComponent().store == "test_store"
 
 
@@ -75,7 +75,7 @@ def test_correct_declaration_with_additional_writable_property():
             return {"output_value": input_value}
 
     # Verifies that instantiation works with no issues
-    assert component.registry["MockComponent"] == MockComponent
+    assert component.registry["test_component.MockComponent"] == MockComponent
     comp = MockComponent()
     comp.store = "test_store"
     assert comp.store == "test_store"

--- a/test/pipeline/integration/test_looping_pipeline.py
+++ b/test/pipeline/integration/test_looping_pipeline.py
@@ -33,7 +33,6 @@ def test_pipeline(tmp_path):
 
     results = pipeline.run({"add_one": {"value": 3}})
     pprint(results)
-    print("accumulator: ", accumulator.state)
 
     assert results == {"add_two": {"result": 18}}
     assert accumulator.state == 16
@@ -55,7 +54,6 @@ def test_pipeline_direct_io_loop(tmp_path):
 
     results = pipeline.run({"merge": {"in_1": 4}})
     pprint(results)
-    print("accumulator: ", accumulator.state)
 
     assert results == {"below_10": {"above": 16}}
     assert accumulator.state == 16
@@ -103,7 +101,6 @@ def test_pipeline_variadic_merger_input(tmp_path):
 
     results = pipeline.run({"merge": {"inputs": 4}})
     pprint(results)
-    print("accumulator: ", accumulator.state)
 
     assert results == {"add_two": {"result": 18}}
     assert accumulator.state == 16

--- a/test/pipeline/unit/test_pipeline.py
+++ b/test/pipeline/unit/test_pipeline.py
@@ -57,15 +57,15 @@ def test_to_dict():
         "max_loops_allowed": 42,
         "components": {
             "add_two": {
-                "type": "AddFixedValue",
+                "type": "sample_components.add_value.AddFixedValue",
                 "init_parameters": {"add": 2},
             },
             "add_default": {
-                "type": "AddFixedValue",
+                "type": "sample_components.add_value.AddFixedValue",
                 "init_parameters": {"add": 1},
             },
             "double": {
-                "type": "Double",
+                "type": "sample_components.double.Double",
                 "init_parameters": {},
             },
         },
@@ -83,15 +83,15 @@ def test_from_dict():
         "max_loops_allowed": 101,
         "components": {
             "add_two": {
-                "type": "AddFixedValue",
+                "type": "sample_components.add_value.AddFixedValue",
                 "init_parameters": {"add": 2},
             },
             "add_default": {
-                "type": "AddFixedValue",
+                "type": "sample_components.add_value.AddFixedValue",
                 "init_parameters": {"add": 1},
             },
             "double": {
-                "type": "Double",
+                "type": "sample_components.double.Double",
                 "init_parameters": {},
             },
         },
@@ -183,7 +183,7 @@ def test_from_dict_with_components_instances():
             "add_two": {},
             "add_default": {},
             "double": {
-                "type": "Double",
+                "type": "sample_components.double.Double",
                 "init_parameters": {},
             },
         },
@@ -281,8 +281,7 @@ def test_from_dict_without_registered_component_type(request):
         "max_loops_allowed": 100,
         "components": {
             "add_two": {
-                # We use the test function name as component type to make sure it's not registered.
-                "type": request.node.name,
+                "type": "foo.bar.baz",
                 "init_parameters": {"add": 2},
             },
         },
@@ -291,7 +290,7 @@ def test_from_dict_without_registered_component_type(request):
     with pytest.raises(PipelineError) as err:
         Pipeline.from_dict(data)
 
-    err.match(f"Component '{request.node.name}' not imported.")
+    err.match(f"Component .+ not imported.")
 
 
 def test_from_dict_without_connection_sender():

--- a/test/sample_components/test_accumulate.py
+++ b/test/sample_components/test_accumulate.py
@@ -12,7 +12,7 @@ def test_to_dict():
     accumulate = Accumulate()
     res = accumulate.to_dict()
     assert res == {
-        "type": "Accumulate",
+        "type": "sample_components.accumulate.Accumulate",
         "init_parameters": {"function": "sample_components.accumulate._default_function"},
     }
 
@@ -21,14 +21,14 @@ def test_to_dict_with_custom_function():
     accumulate = Accumulate(function=my_subtract)
     res = accumulate.to_dict()
     assert res == {
-        "type": "Accumulate",
+        "type": "sample_components.accumulate.Accumulate",
         "init_parameters": {"function": "test.sample_components.test_accumulate.my_subtract"},
     }
 
 
 def test_from_dict():
     data = {
-        "type": "Accumulate",
+        "type": "sample_components.accumulate.Accumulate",
         "init_parameters": {},
     }
     accumulate = Accumulate.from_dict(data)
@@ -37,7 +37,7 @@ def test_from_dict():
 
 def test_from_dict_with_default_function():
     data = {
-        "type": "Accumulate",
+        "type": "sample_components.accumulate.Accumulate",
         "init_parameters": {"function": "sample_components.accumulate._default_function"},
     }
     accumulate = Accumulate.from_dict(data)
@@ -46,7 +46,7 @@ def test_from_dict_with_default_function():
 
 def test_from_dict_with_custom_function():
     data = {
-        "type": "Accumulate",
+        "type": "sample_components.accumulate.Accumulate",
         "init_parameters": {"function": "test.sample_components.test_accumulate.my_subtract"},
     }
     accumulate = Accumulate.from_dict(data)

--- a/test/sample_components/test_add_value.py
+++ b/test/sample_components/test_add_value.py
@@ -5,30 +5,6 @@ from sample_components import AddFixedValue
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = AddFixedValue()
-    res = component_to_dict(component)
-    assert res == {"type": "AddFixedValue", "init_parameters": {"add": 1}}
-
-
-def test_to_dict_with_custom_add_value():
-    component = AddFixedValue(add=100)
-    res = component_to_dict(component)
-    assert res == {"type": "AddFixedValue", "init_parameters": {"add": 100}}
-
-
-def test_from_dict():
-    data = {"type": "AddFixedValue"}
-    component = component_from_dict(AddFixedValue, data)
-    assert component.add == 1
-
-
-def test_from_dict_with_custom_add_value():
-    data = {"type": "AddFixedValue", "init_parameters": {"add": 100}}
-    component = component_from_dict(AddFixedValue, data)
-    assert component.add == 100
-
-
 def test_run():
     component = AddFixedValue()
     results = component.run(value=50, add=10)

--- a/test/sample_components/test_concatenate.py
+++ b/test/sample_components/test_concatenate.py
@@ -5,18 +5,6 @@ from sample_components import Concatenate
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Concatenate()
-    res = component_to_dict(component)
-    assert res == {"type": "Concatenate", "init_parameters": {}}
-
-
-def test_from_dict():
-    data = {"type": "Concatenate", "init_parameters": {}}
-    component = component_from_dict(Concatenate, data)
-    assert component
-
-
 def test_input_lists():
     component = Concatenate()
     res = component.run(first=["This"], second=["That"])

--- a/test/sample_components/test_double.py
+++ b/test/sample_components/test_double.py
@@ -6,18 +6,6 @@ from sample_components import Double
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Double()
-    res = component_to_dict(component)
-    assert res == {"type": "Double", "init_parameters": {}}
-
-
-def test_from_dict():
-    data = {"type": "Double", "init_parameters": {}}
-    component = component_from_dict(Double, data)
-    assert component
-
-
 def test_double_default():
     component = Double()
     results = component.run(value=10)

--- a/test/sample_components/test_greet.py
+++ b/test/sample_components/test_greet.py
@@ -7,50 +7,6 @@ from sample_components import Greet
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Greet()
-    res = component_to_dict(component)
-    assert res == {
-        "type": "Greet",
-        "init_parameters": {
-            "message": "\nGreeting component says: Hi! The value is {value}\n",
-            "log_level": "INFO",
-        },
-    }
-
-
-def test_to_dict_with_custom_parameters():
-    component = Greet(message="My message", log_level="ERROR")
-    res = component_to_dict(component)
-    assert res == {
-        "type": "Greet",
-        "init_parameters": {
-            "message": "My message",
-            "log_level": "ERROR",
-        },
-    }
-
-
-def test_from_dict():
-    data = {
-        "type": "Greet",
-        "init_parameters": {},
-    }
-    component = component_from_dict(Greet, data)
-    assert component.message == "\nGreeting component says: Hi! The value is {value}\n"
-    assert component.log_level == "INFO"
-
-
-def test_from_with_custom_parameters():
-    data = {
-        "type": "Greet",
-        "init_parameters": {"message": "My message", "log_level": "ERROR"},
-    }
-    component = component_from_dict(Greet, data)
-    assert component.message == "My message"
-    assert component.log_level == "ERROR"
-
-
 def test_greet_message(caplog):
     caplog.set_level(logging.WARNING)
     component = Greet()

--- a/test/sample_components/test_merge_loop.py
+++ b/test/sample_components/test_merge_loop.py
@@ -14,7 +14,7 @@ def test_to_dict():
     component = MergeLoop(expected_type=int, inputs=["first", "second"])
     res = component.to_dict()
     assert res == {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {"expected_type": "builtins.int", "inputs": ["first", "second"]},
     }
 
@@ -23,7 +23,7 @@ def test_to_dict_with_typing_class():
     component = MergeLoop(expected_type=Dict, inputs=["first", "second"])
     res = component.to_dict()
     assert res == {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "expected_type": "typing.Dict",
             "inputs": ["first", "second"],
@@ -35,7 +35,7 @@ def test_to_dict_with_custom_class():
     component = MergeLoop(expected_type=MergeLoop, inputs=["first", "second"])
     res = component.to_dict()
     assert res == {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "expected_type": "sample_components.merge_loop.MergeLoop",
             "inputs": ["first", "second"],
@@ -45,7 +45,7 @@ def test_to_dict_with_custom_class():
 
 def test_from_dict():
     data = {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {"expected_type": "builtins.int", "inputs": ["first", "second"]},
     }
     component = MergeLoop.from_dict(data)
@@ -55,7 +55,7 @@ def test_from_dict():
 
 def test_from_dict_with_typing_class():
     data = {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "expected_type": "typing.Dict",
             "inputs": ["first", "second"],
@@ -68,7 +68,7 @@ def test_from_dict_with_typing_class():
 
 def test_from_dict_with_custom_class():
     data = {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "expected_type": "sample_components.merge_loop.MergeLoop",
             "inputs": ["first", "second"],
@@ -81,7 +81,7 @@ def test_from_dict_with_custom_class():
 
 def test_from_dict_without_expected_type():
     data = {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "inputs": ["first", "second"],
         },
@@ -94,7 +94,7 @@ def test_from_dict_without_expected_type():
 
 def test_from_dict_without_inputs():
     data = {
-        "type": "MergeLoop",
+        "type": "sample_components.merge_loop.MergeLoop",
         "init_parameters": {
             "expected_type": "sample_components.merge_loop.MergeLoop",
         },

--- a/test/sample_components/test_parity.py
+++ b/test/sample_components/test_parity.py
@@ -5,18 +5,6 @@ from sample_components import Parity
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Parity()
-    res = component_to_dict(component)
-    assert res == {"type": "Parity", "init_parameters": {}}
-
-
-def test_from_dict():
-    data = {"type": "Parity", "init_parameters": {}}
-    component = component_from_dict(Parity, data)
-    assert component
-
-
 def test_parity():
     component = Parity()
     results = component.run(value=1)

--- a/test/sample_components/test_remainder.py
+++ b/test/sample_components/test_remainder.py
@@ -7,30 +7,6 @@ from sample_components import Remainder
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Remainder()
-    res = component_to_dict(component)
-    assert res == {"type": "Remainder", "init_parameters": {"divisor": 3}}
-
-
-def test_to_dict_with_custom_divisor_value():
-    component = Remainder(divisor=100)
-    res = component_to_dict(component)
-    assert res == {"type": "Remainder", "init_parameters": {"divisor": 100}}
-
-
-def test_from_dict():
-    data = {"type": "Remainder"}
-    component = component_from_dict(Remainder, data)
-    assert component.divisor == 3
-
-
-def test_from_dict_with_custom_divisor_value():
-    data = {"type": "Remainder", "init_parameters": {"divisor": 100}}
-    component = component_from_dict(Remainder, data)
-    assert component.divisor == 100
-
-
 def test_remainder_default():
     component = Remainder()
     results = component.run(value=4)

--- a/test/sample_components/test_repeat.py
+++ b/test/sample_components/test_repeat.py
@@ -5,18 +5,6 @@ from sample_components import Repeat
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Repeat(outputs=["first", "second"])
-    res = component_to_dict(component)
-    assert res == {"type": "Repeat", "init_parameters": {"outputs": ["first", "second"]}}
-
-
-def test_from_dict():
-    data = {"type": "Repeat", "init_parameters": {"outputs": ["first", "second"]}}
-    component = component_from_dict(Repeat, data)
-    assert component.outputs == ["first", "second"]
-
-
 def test_repeat_default():
     component = Repeat(outputs=["one", "two"])
     results = component.run(value=10)

--- a/test/sample_components/test_subtract.py
+++ b/test/sample_components/test_subtract.py
@@ -5,18 +5,6 @@ from sample_components import Subtract
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Subtract()
-    res = component_to_dict(component)
-    assert res == {"type": "Subtract", "init_parameters": {}}
-
-
-def test_from_dict():
-    data = {"type": "Subtract", "init_parameters": {}}
-    component = component_from_dict(Subtract, data)
-    assert component
-
-
 def test_subtract():
     component = Subtract()
     results = component.run(first_value=10, second_value=7)

--- a/test/sample_components/test_sum.py
+++ b/test/sample_components/test_sum.py
@@ -6,17 +6,6 @@ from sample_components import Sum
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Sum()
-    res = component_to_dict(component)
-    assert res == {"type": "Sum", "init_parameters": {}}
-
-
-def test_from_dict():
-    data = {"type": "Sum", "init_parameters": {}}
-    component = component_from_dict(Sum, data)
-
-
 def test_sum_receives_no_values():
     component = Sum()
     results = component.run(values=[])

--- a/test/sample_components/test_threshold.py
+++ b/test/sample_components/test_threshold.py
@@ -5,30 +5,6 @@ from sample_components import Threshold
 from canals.serialization import component_to_dict, component_from_dict
 
 
-def test_to_dict():
-    component = Threshold()
-    res = component_to_dict(component)
-    assert res == {"type": "Threshold", "init_parameters": {"threshold": 10}}
-
-
-def test_to_dict_with_custom_threshold_value():
-    component = Threshold(threshold=100)
-    res = component_to_dict(component)
-    assert res == {"type": "Threshold", "init_parameters": {"threshold": 100}}
-
-
-def test_from_dict():
-    data = {"type": "Threshold"}
-    component = component_from_dict(Threshold, data)
-    assert component.threshold == 10
-
-
-def test_from_dict_with_custom_threshold_value():
-    data = {"type": "Threshold", "init_parameters": {"threshold": 100}}
-    component = component_from_dict(Threshold, data)
-    assert component.threshold == 100
-
-
 def test_threshold():
     component = Threshold()
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,8 +1,9 @@
+import sys
 from unittest.mock import Mock
 
 import pytest
 
-from canals import Pipeline
+from canals import Pipeline, component
 from canals.errors import DeserializationError
 from canals.testing import factory
 from canals.serialization import default_to_dict, default_from_dict
@@ -77,5 +78,14 @@ def test_from_dict_import_type():
         "connections": [],
     }
 
+    # remove the target component from the registry if already there
+    component.registry.pop("sample_components.greet.Greet", None)
+    # remove the module from sys.modules if already there
+    sys.modules.pop("sample_components.greet", None)
+
     p = Pipeline.from_dict(pipeline_dict)
-    print(p)
+
+    from sample_components.greet import Greet
+
+    assert type(p.get_component("greeter")) == Greet
+    assert type(p.get_component("greeter")) == Greet

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from canals import Pipeline
 from canals.errors import DeserializationError
 from canals.testing import factory
 from canals.serialization import default_to_dict, default_from_dict
@@ -12,7 +13,7 @@ def test_default_component_to_dict():
     comp = MyComponent()
     res = default_to_dict(comp)
     assert res == {
-        "type": "MyComponent",
+        "type": "canals.testing.factory.MyComponent",
         "init_parameters": {},
     }
 
@@ -22,7 +23,7 @@ def test_default_component_to_dict_with_init_parameters():
     comp = MyComponent()
     res = default_to_dict(comp, some_key="some_value")
     assert res == {
-        "type": "MyComponent",
+        "type": "canals.testing.factory.MyComponent",
         "init_parameters": {"some_key": "some_value"},
     }
 
@@ -36,7 +37,7 @@ def test_default_component_from_dict():
     comp = default_from_dict(
         MyComponent,
         {
-            "type": "MyComponent",
+            "type": "canals.testing.factory.MyComponent",
             "init_parameters": {
                 "some_param": 10,
             },
@@ -58,3 +59,23 @@ def test_default_component_from_dict_unregistered_component(request):
 
     with pytest.raises(DeserializationError, match=f"Class '{component_name}' can't be deserialized as 'Mock'"):
         default_from_dict(Mock, {"type": component_name})
+
+
+def test_from_dict_import_type():
+    pipeline_dict = {
+        "metadata": {},
+        "max_loops_allowed": 100,
+        "components": {
+            "greeter": {
+                "type": "sample_components.greet.Greet",
+                "init_parameters": {
+                    "message": "\nGreeting component says: Hi! The value is {value}\n",
+                    "log_level": "INFO",
+                },
+            }
+        },
+        "connections": [],
+    }
+
+    p = Pipeline.from_dict(pipeline_dict)
+    print(p)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -88,4 +88,3 @@ def test_from_dict_import_type():
     from sample_components.greet import Greet
 
     assert type(p.get_component("greeter")) == Greet
-    assert type(p.get_component("greeter")) == Greet

--- a/test/testing/test_factory.py
+++ b/test/testing/test_factory.py
@@ -20,7 +20,7 @@ def test_component_class_default():
 
 def test_component_class_is_registered():
     MyComponent = factory.component_class("MyComponent")
-    assert component.registry["MyComponent"] == MyComponent
+    assert component.registry["canals.testing.factory.MyComponent"] == MyComponent
 
 
 def test_component_class_with_input_types():


### PR DESCRIPTION
fixes: https://github.com/deepset-ai/haystack/issues/6186

## Changes

- Use full import path of the component as `type` in its dict representation
- Try to import the full path when deserializing a component

Before:
```py
pipeline_dict = {
    "components": {
        "greeter": {
            "type": "Greet",
            "init_parameters": {
                "message": "\nGreeting component says: Hi! The value is {value}\n",
                "log_level": "INFO",
            },
        }
    },
   ...
}
```

After:
```py
pipeline_dict = {
    "components": {
        "greeter": {
            "type": "sample_components.greet.Greet",  # <-- Now we use the full import path to represent the type
            "init_parameters": {
                "message": "\nGreeting component says: Hi! The value is {value}\n",
                "log_level": "INFO",
            },
        }
    },
   ...
}
```